### PR TITLE
fix: add fallback for parsing AI responses with leading '+' symbols

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -735,7 +735,7 @@ def try_fix_yaml(response_text: str,
         get_logger().info(f"Successfully parsed AI prediction after adding |-\n")
         return data
     except:
-        get_logger().info(f"Failed to parse AI prediction after adding |-\n")
+        pass
 
     # second fallback - try to extract only range from first ```yaml to ````
     snippet_pattern = r'```(yaml)?[\s\S]*?```'
@@ -779,9 +779,18 @@ def try_fix_yaml(response_text: str,
         except:
             pass
 
+    # fifth fallback - try to remove leading '+' (sometimes added by AI for 'existing code' and 'improved code')
+    response_text_lines_copy = response_text_lines.copy()
+    for i in range(0, len(response_text_lines_copy)):
+        response_text_lines_copy[i] = ' ' + response_text_lines_copy[i][1:]
+    try:
+        data = yaml.safe_load('\n'.join(response_text_lines_copy))
+        get_logger().info(f"Successfully parsed AI prediction after removing leading '+'")
+        return data
+    except:
+        pass
 
-    # fifth fallback - try to remove last lines
-    data = {}
+    # sixth fallback - try to remove last lines
     for i in range(1, len(response_text_lines)):
         response_text_lines_tmp = '\n'.join(response_text_lines[:-i])
         try:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a fallback to handle AI responses with leading '+' symbols.

- Improved error handling by refining fallback mechanisms.

- Adjusted logging to reflect parsing attempts and outcomes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Add fallback for AI responses with leading '+'</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/utils.py

<li>Added a new fallback to remove leading '+' symbols from AI responses.<br> <li> Updated logging to indicate successful parsing after applying the new <br>fallback.<br> <li> Adjusted fallback sequence to improve parsing robustness.<br> <li> Refined existing fallback mechanisms for better error handling.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1506/files#diff-6b9df72d53c6f0d89fb142c210238a276c0782305e0024d16fbfcaf72c2e2b53">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>