### PR TITLE
fix: update review effort label format to use X/5 notation

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -371,7 +371,7 @@ class PRReviewer:
                     else:
                         get_logger().warning(f"Unexpected type for estimated_effort: {type(estimated_effort)}")
                     if 1 <= estimated_effort_number <= 5:  # 1, because ...
-                        review_labels.append(f'Review effort [1-5]: {estimated_effort_number}')
+                        review_labels.append(f'Review effort {estimated_effort_number}/5')
                 if get_settings().pr_reviewer.enable_review_labels_security and get_settings().pr_reviewer.require_security_review:
                     security_concerns = data['review']['security_concerns']  # yes, because ...
                     security_concerns_bool = 'yes' in security_concerns.lower() or 'true' in security_concerns.lower()


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated review effort label format to `X/5` notation.

- Ensured consistent formatting for review effort labels.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer.py</strong><dd><code>Update review effort label format to `X/5`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_reviewer.py

<li>Changed review effort label format from <code>[1-5]: X</code> to <code>X/5</code>.<br> <li> Improved clarity and consistency in label representation.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1532/files#diff-8e265068e189a06852605cc694b03e92b523b4f8162077a2f3455ced4cdad8dc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>