### PR TITLE
Fix prompt to not output diff prefixes in existing_code,improved_code pydantic definitions

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -782,7 +782,8 @@ def try_fix_yaml(response_text: str,
     # fifth fallback - try to remove leading '+' (sometimes added by AI for 'existing code' and 'improved code')
     response_text_lines_copy = response_text_lines.copy()
     for i in range(0, len(response_text_lines_copy)):
-        response_text_lines_copy[i] = ' ' + response_text_lines_copy[i][1:]
+        if response_text_lines_copy[i].startswith('+'):
+            response_text_lines_copy[i] = ' ' + response_text_lines_copy[i][1:]
     try:
         data = yaml.safe_load('\n'.join(response_text_lines_copy))
         get_logger().info(f"Successfully parsed AI prediction after removing leading '+'")

--- a/pr_agent/settings/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/pr_code_suggestions_prompts.toml
@@ -84,8 +84,8 @@ class CodeSuggestion(BaseModel):
     relevant_file: str = Field(description="Full path of the relevant file")
     language: str = Field(description="Programming language used by the relevant file")
     suggestion_content: str = Field(description="An actionable suggestion to enhance, improve or fix the new code introduced in the PR. Don't present here actual code snippets, just the suggestion. Be short and concise")
-    existing_code: str = Field(description="A short code snippet, from a '__new hunk__' section after the PR changes, that the suggestion aims to enhance or fix. Include only complete code lines. Use ellipsis (...) for brevity if needed. This snippet should represent the specific PR code targeted for improvement.")
-    improved_code: str = Field(description="A refined code snippet that replaces the 'existing_code' snippet after implementing the suggestion.")
+    existing_code: str = Field(description="A short code snippet, from a '__new hunk__' section after the PR changes, that the suggestion aims to enhance or fix. Include only complete code lines without diff prefixes like '+', '-'. Use ellipsis (...) for brevity if needed. This snippet should represent the specific PR code targeted for improvement.")
+    improved_code: str = Field(description="A refined code snippet that replaces the 'existing_code' snippet after implementing the suggestion. Include only complete code lines without diff prefixes like '+', '-'.")
     one_sentence_summary: str = Field(description="A concise, single-sentence overview (up to 6 words) of the suggested improvement. Focus on the 'what'. Be general, and avoid method or variable names.")
 {%- if not focus_only_on_problems %}
     label: str = Field(description="A single, descriptive label that best characterizes the suggestion type. Possible labels include 'security', 'possible bug', 'possible issue', 'performance', 'enhancement', 'best practice', 'maintainability', 'typo'. Other relevant labels are also acceptable.")

--- a/pr_agent/settings/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/pr_code_suggestions_prompts.toml
@@ -84,8 +84,8 @@ class CodeSuggestion(BaseModel):
     relevant_file: str = Field(description="Full path of the relevant file")
     language: str = Field(description="Programming language used by the relevant file")
     suggestion_content: str = Field(description="An actionable suggestion to enhance, improve or fix the new code introduced in the PR. Don't present here actual code snippets, just the suggestion. Be short and concise")
-    existing_code: str = Field(description="A short code snippet, from a '__new hunk__' section after the PR changes, that the suggestion aims to enhance or fix. Include only complete code lines without diff prefixes like '+', '-'. Use ellipsis (...) for brevity if needed. This snippet should represent the specific PR code targeted for improvement.")
-    improved_code: str = Field(description="A refined code snippet that replaces the 'existing_code' snippet after implementing the suggestion. Include only complete code lines without diff prefixes like '+', '-'.")
+    existing_code: str = Field(description="A short code snippet, from a '__new hunk__' section after the PR changes, that the suggestion aims to enhance or fix. Include only complete code lines. Use ellipsis (...) for brevity if needed. This snippet should represent the specific PR code targeted for improvement.")
+    improved_code: str = Field(description="A refined code snippet that replaces the 'existing_code' snippet after implementing the suggestion. Include only complete code lines.")
     one_sentence_summary: str = Field(description="A concise, single-sentence overview (up to 6 words) of the suggested improvement. Focus on the 'what'. Be general, and avoid method or variable names.")
 {%- if not focus_only_on_problems %}
     label: str = Field(description="A single, descriptive label that best characterizes the suggestion type. Possible labels include 'security', 'possible bug', 'possible issue', 'performance', 'enhancement', 'best practice', 'maintainability', 'typo'. Other relevant labels are also acceptable.")

--- a/pr_agent/settings/pr_code_suggestions_prompts.toml
+++ b/pr_agent/settings/pr_code_suggestions_prompts.toml
@@ -85,7 +85,7 @@ class CodeSuggestion(BaseModel):
     language: str = Field(description="Programming language used by the relevant file")
     suggestion_content: str = Field(description="An actionable suggestion to enhance, improve or fix the new code introduced in the PR. Don't present here actual code snippets, just the suggestion. Be short and concise")
     existing_code: str = Field(description="A short code snippet, from a '__new hunk__' section after the PR changes, that the suggestion aims to enhance or fix. Include only complete code lines. Use ellipsis (...) for brevity if needed. This snippet should represent the specific PR code targeted for improvement.")
-    improved_code: str = Field(description="A refined code snippet that replaces the 'existing_code' snippet after implementing the suggestion. Include only complete code lines.")
+    improved_code: str = Field(description="A refined code snippet that replaces the 'existing_code' snippet after implementing the suggestion.")
     one_sentence_summary: str = Field(description="A concise, single-sentence overview (up to 6 words) of the suggested improvement. Focus on the 'what'. Be general, and avoid method or variable names.")
 {%- if not focus_only_on_problems %}
     label: str = Field(description="A single, descriptive label that best characterizes the suggestion type. Possible labels include 'security', 'possible bug', 'possible issue', 'performance', 'enhancement', 'best practice', 'maintainability', 'typo'. Other relevant labels are also acceptable.")


### PR DESCRIPTION
### **User description**
### Problem
Found while testing the DEEPSEEK-R1 model, YAML parsing for code suggestion responses was failing.
For reference, we are separating and processing the listening responses (<think>..</think>) normally, and the YAML parsing of the final response is failing.

### Root cause
A parsing error occurred in the existing_code and improved_code parts, causing code with diff prefixes to be generated, which ignored the yaml indent.
```
code_suggestions:
- relevant_file: |
    lca.py
  language: |
    python
  suggestion_content: |
    ....
  existing_code: |
    if (not findPath(root, path1, n1) or not findPath(root, path2, n2)):
+        return 0
  improved_code: |
    if (not findPath(root, path1, n1) or not findPath(root, path2, n2)):
        return -1
  one_sentence_summary: |
    ....
  label: |
    critical bug
```
### Approach
Initially, I attempted to modify the prompt to ensure that the diff prefix also adheres to the indent. However, upon reviewing the code, I found that the existing_code and improved_code were merged using unified diff in the code logic. Therefore, I confirmed that the diff prefix should not be included in the llm's response.

### Solution
Add instructions to the definitions of existing_code and improved_code in Pydantic definition to ensure that the diff prefix is not included in the output.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed handling of leading '+' in YAML parsing.

- Improved robustness of `try_fix_yaml` function.

- Ensured proper formatting for AI-generated code suggestions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Improve YAML parsing by handling leading '+'</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/utils.py

<li>Added a condition to check for lines starting with '+'.<br> <li> Modified lines to remove the leading '+' when present.<br> <li> Enhanced YAML parsing logic to handle AI-generated responses.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1556/files#diff-6b9df72d53c6f0d89fb142c210238a276c0782305e0024d16fbfcaf72c2e2b53">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>