### PR TITLE
Support reasoning effort via configuration

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -212,4 +212,4 @@ To bypass chat templates and temperature controls, set `config.custom_reasoning_
 [config]
 reasoning_efffort= = "medium" # "low", "medium", "high"
 
-With the OpenAI models that support reasoning effort (eg: o3-mini), you can specify its reasoning effort via `config` section. The default value is `medium`, you change it to `high` or `low` based on usages.
+With the OpenAI models that support reasoning effort (eg: o3-mini), you can specify its reasoning effort via `config` section. The default value is `medium`. You can change it to `high` or `low` based on your usage.

--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -204,3 +204,12 @@ custom_model_max_tokens= ...
 
 4. Most reasoning models do not support chat-style inputs (`system` and `user` messages) or temperature settings. 
 To bypass chat templates and temperature controls, set `config.custom_reasoning_model = true` in your configuration file.
+
+## Dedicated parameters
+
+### OpenAI models
+
+[config]
+reasoning_efffort= = "medium" # "low", "medium", "high"
+
+With the OpenAI models that support reasoning effort (eg: o3-mini), you can specify its reasoning effort via `config` section. The default value is `medium`, you change it to `high` or `low` based on usages.

--- a/pr_agent/algo/__init__.py
+++ b/pr_agent/algo/__init__.py
@@ -101,3 +101,8 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "o3-mini-2025-01-31",
     "o1-preview"
 ]
+
+SUPPORT_REASONING_EFFORT_MODELS = [
+    "o3-mini",
+    "o3-mini-2025-01-31"
+]

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -6,9 +6,9 @@ import requests
 from litellm import acompletion
 from tenacity import retry, retry_if_exception_type, stop_after_attempt
 
-from pr_agent.algo import NO_SUPPORT_TEMPERATURE_MODELS, USER_MESSAGE_ONLY_MODELS
+from pr_agent.algo import NO_SUPPORT_TEMPERATURE_MODELS, SUPPORT_REASONING_EFFORT_MODELS, USER_MESSAGE_ONLY_MODELS
 from pr_agent.algo.ai_handlers.base_ai_handler import BaseAiHandler
-from pr_agent.algo.utils import get_version
+from pr_agent.algo.utils import ReasoningEffort, get_version
 from pr_agent.config_loader import get_settings
 from pr_agent.log import get_logger
 
@@ -100,6 +100,9 @@ class LiteLLMAIHandler(BaseAiHandler):
 
         # Model that doesn't support temperature argument
         self.no_support_temperature_models = NO_SUPPORT_TEMPERATURE_MODELS
+
+        # Models that support reasoning effort
+        self.support_reasoning_models = SUPPORT_REASONING_EFFORT_MODELS
 
     def prepare_logs(self, response, system, user, resp, finish_reason):
         response_log = response.dict().copy()
@@ -229,6 +232,13 @@ class LiteLLMAIHandler(BaseAiHandler):
             # Add temperature only if model supports it
             if model not in self.no_support_temperature_models and not get_settings().config.custom_reasoning_model:
                 kwargs["temperature"] = temperature
+
+            # Add reasoning_effort if model supports it
+            if (model in self.support_reasoning_models):
+                supported_reasoning_efforts = [ReasoningEffort.HIGH.value, ReasoningEffort.MEDIUM.value, ReasoningEffort.LOW.value]
+                reasoning_effort = get_settings().config.reasoning_effort if (get_settings().config.reasoning_effort in supported_reasoning_efforts) else ReasoningEffort.MEDIUM.value
+                get_logger().info(f"Add reasoning_effort with value {reasoning_effort} to model {model}.")
+                kwargs["reasoning_effort"] = reasoning_effort
 
             if get_settings().litellm.get("enable_callbacks", False):
                 kwargs = self.add_litellm_callbacks(kwargs)

--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -231,13 +231,14 @@ class LiteLLMAIHandler(BaseAiHandler):
 
             # Add temperature only if model supports it
             if model not in self.no_support_temperature_models and not get_settings().config.custom_reasoning_model:
+                get_logger().info(f"Adding temperature with value {temperature} to model {model}.")
                 kwargs["temperature"] = temperature
 
             # Add reasoning_effort if model supports it
             if (model in self.support_reasoning_models):
                 supported_reasoning_efforts = [ReasoningEffort.HIGH.value, ReasoningEffort.MEDIUM.value, ReasoningEffort.LOW.value]
                 reasoning_effort = get_settings().config.reasoning_effort if (get_settings().config.reasoning_effort in supported_reasoning_efforts) else ReasoningEffort.MEDIUM.value
-                get_logger().info(f"Add reasoning_effort with value {reasoning_effort} to model {model}.")
+                get_logger().info(f"Adding reasoning_effort with value {reasoning_effort} to model {model}.")
                 kwargs["reasoning_effort"] = reasoning_effort
 
             if get_settings().litellm.get("enable_callbacks", False):

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -50,6 +50,11 @@ class PRReviewHeader(str, Enum):
     REGULAR = "## PR Reviewer Guide"
     INCREMENTAL = "## Incremental PR Reviewer Guide"
 
+class ReasoningEffort(str, Enum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
 
 class PRDescriptionHeader(str, Enum):
     CHANGES_WALKTHROUGH = "### **Changes walkthrough** 📝"

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -48,6 +48,7 @@ ignore_pr_authors = [] # authors to ignore from PR agent when an PR is created
 #
 is_auto_command = false # will be auto-set to true if the command is triggered by an automation
 enable_ai_metadata = false # will enable adding ai metadata
+reasoning_effort = "medium" # "low", "medium", "high"
 
 [pr_reviewer] # /review #
 # enable/disable features


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added support for `reasoning_effort` configuration in AI models.

- Introduced `ReasoningEffort` enum for reasoning effort levels.

- Updated `chat_completion` to include `reasoning_effort` parameter.

- Extended configuration file to allow setting `reasoning_effort`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Added support for reasoning effort models.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/__init__.py

- Defined `SUPPORT_REASONING_EFFORT_MODELS` list for specific models.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1561/files#diff-5923c546f24ec7308a0e43fc84bb6fe40de7bfe2ac6ee842da9578e5dc2c692b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>litellm_ai_handler.py</strong><dd><code>Enhanced AI handler to support reasoning effort.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/ai_handlers/litellm_ai_handler.py

<li>Imported <code>ReasoningEffort</code> and <code>SUPPORT_REASONING_EFFORT_MODELS</code>.<br> <li> Added <code>support_reasoning_models</code> attribute.<br> <li> Updated <code>chat_completion</code> to handle <code>reasoning_effort</code> parameter.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1561/files#diff-ea1acaa0907f3410665530fbc4cda2ab524de2772e0bbe10bad4648b8be35dfe">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Added ReasoningEffort enum for reasoning levels.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/utils.py

- Introduced `ReasoningEffort` enum with levels: HIGH, MEDIUM, LOW.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1561/files#diff-6b9df72d53c6f0d89fb142c210238a276c0782305e0024d16fbfcaf72c2e2b53">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Extended configuration for reasoning effort setting.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml

- Added `reasoning_effort` configuration option with default value.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1561/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>