### PR TITLE
Fixes HTML base url logic

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -37,7 +37,8 @@ class GithubProvider(GitProvider):
             self.installation_id = None
         self.max_comment_chars = 65000
         self.base_url = get_settings().get("GITHUB.BASE_URL", "https://api.github.com").rstrip("/") # "https://api.github.com"
-        self.base_url_html = self.base_url.split("api/")[0].rstrip("/") if "api/" in self.base_url else "https://github.com"
+        base_url = urlparse(self.base_url)
+        self.base_url_html = f"{base_url.scheme}://{base_url.netloc[4:] if base_url.netloc.startswith('api.') else 'https://github.com'}"
         self.github_client = self._get_github_client()
         self.repo = None
         self.pr_num = None


### PR DESCRIPTION
### **PR Type**
Bug fix

I am unsure as to what the logic beforehand was trying to accomplish. When would `api/` ever be present in the base_url? Not sure if this was a typo of some sort. I've modified the logic to just strip `api` from the baseurl. 
This fixes the situation we are encountering with a base_url of: `https://api.git.local` resulting in a html url of `https://github.com`

This logic will handle any case:

```
https://api.git.local -> https://git.local
https://api.git.local/api/v3 -> https://git.local
```


___

### **Description**
- Fixed the logic for determining `base_url_html`.

- Improved handling of `base_url` parsing using `urlparse`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_provider.py</strong><dd><code>Fix and enhance `base_url_html` logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/github_provider.py

<li>Replaced logic for <code>base_url_html</code> determination.<br> <li> Used <code>urlparse</code> for parsing <code>base_url</code>.<br> <li> Adjusted handling of <code>base_url</code> to ensure correct HTML URL generation.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1591/files#diff-28979ec713529d6f619bcba0b9e6a3002d1164d47c70ccfea7f15306618a1a11">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>