### PR TITLE
fix: repeat processing files to ignore

### DIFF
--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -50,21 +50,10 @@ def get_pr_diff(git_provider: GitProvider, token_handler: TokenHandler,
         PATCH_EXTRA_LINES_AFTER = cap_and_log_extra_lines(PATCH_EXTRA_LINES_AFTER, "after")
 
     try:
-        diff_files_original = git_provider.get_diff_files()
+        diff_files = git_provider.get_diff_files()
     except RateLimitExceededException as e:
         get_logger().error(f"Rate limit exceeded for git provider API. original message {e}")
         raise
-
-    diff_files = filter_ignored(diff_files_original)
-    if diff_files != diff_files_original:
-        try:
-            get_logger().info(f"Filtered out {len(diff_files_original) - len(diff_files)} files")
-            new_names = set([a.filename for a in diff_files])
-            orig_names = set([a.filename for a in diff_files_original])
-            get_logger().info(f"Filtered out files: {orig_names - new_names}")
-        except Exception as e:
-            pass
-
 
     # get pr languages
     pr_languages = sort_files_by_main_languages(git_provider.get_languages(), diff_files)
@@ -155,20 +144,10 @@ def get_pr_diff(git_provider: GitProvider, token_handler: TokenHandler,
 def get_pr_diff_multiple_patchs(git_provider: GitProvider, token_handler: TokenHandler, model: str,
                 add_line_numbers_to_hunks: bool = False, disable_extra_lines: bool = False):
     try:
-        diff_files_original = git_provider.get_diff_files()
+        diff_files = git_provider.get_diff_files()
     except RateLimitExceededException as e:
         get_logger().error(f"Rate limit exceeded for git provider API. original message {e}")
         raise
-
-    diff_files = filter_ignored(diff_files_original)
-    if diff_files != diff_files_original:
-        try:
-            get_logger().info(f"Filtered out {len(diff_files_original) - len(diff_files)} files")
-            new_names = set([a.filename for a in diff_files])
-            orig_names = set([a.filename for a in diff_files_original])
-            get_logger().info(f"Filtered out files: {orig_names - new_names}")
-        except Exception as e:
-            pass
 
     # get pr languages
     pr_languages = sort_files_by_main_languages(git_provider.get_languages(), diff_files)
@@ -409,8 +388,6 @@ def get_pr_multi_diffs(git_provider: GitProvider,
     except RateLimitExceededException as e:
         get_logger().error(f"Rate limit exceeded for git provider API. original message {e}")
         raise
-
-    diff_files = filter_ignored(diff_files)
 
     # Sort files by main language
     pr_languages = sort_files_by_main_languages(git_provider.get_languages(), diff_files)


### PR DESCRIPTION
### **User description**
The corresponding file has already been excluded in the git_provider.get_diff_files() method
```
  def get_diff_files(self) -> list[FilePatchInfo]:
        """
        Retrieves the list of files that have been modified, added, deleted, or renamed in a pull request in GitLab,
        along with their content and patch information.

        Returns:
            diff_files (List[FilePatchInfo]): List of FilePatchInfo objects representing the modified, added, deleted,
            or renamed files in the merge request.
        """

        if self.diff_files:
            return self.diff_files

        # filter files using [ignore] patterns
        diffs_original = self.mr.changes()['changes']
        diffs = filter_ignored(diffs_original, 'gitlab')
        ....
```
and there's no platform prama here, so I think it's redundant


___

### **PR Type**
Bug fix


___

### **Description**
- Removed redundant filtering of ignored files in `get_pr_multi_diffs`.

- Ensured filtering is handled only in `git_provider.get_diff_files`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_processing.py</strong><dd><code>Remove redundant filtering logic in PR processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/pr_processing.py

<li>Removed a redundant call to <code>filter_ignored</code>.<br> <li> Simplified the logic by relying on <code>git_provider.get_diff_files</code>.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1612/files#diff-c2d64de584ef3cb05c9007d72137f6c7ce04c9bc23ce1931760af3a568edb04e">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>