### PR TITLE
Update azuredevops_provider.py

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -383,7 +383,7 @@ class AzureDevopsProvider(GitProvider):
             get_logger().debug(f"Skipping publish_comment for temporary comment: {pr_comment}")
             return None
         comment = Comment(content=pr_comment)
-        thread = CommentThread(comments=[comment], thread_context=thread_context, status=5)
+        thread = CommentThread(comments=[comment], thread_context=thread_context, status=1)
         thread_response = self.azure_devops_client.create_thread(
             comment_thread=thread,
             project=self.workspace_slug,


### PR DESCRIPTION
### **User description**
Will make qodo agent comments "Active" by default, and not "ByDesign" which is renders to "unknown" on Azure DevOps PRs. With this, PR authors are obliged to treat the PR comment of the qodo agent before Merging. This will help companies in analysing the impact of qodo agent on their PR, as every comment needs to be treated as either "Resolved" "Won't fix" "Close"


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Changed default status of qodo agent comments to "Active".

- Ensures PR authors address qodo agent comments before merging.

- Improves clarity and impact analysis of qodo agent comments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_provider.py</strong><dd><code>Change default comment status to "Active"</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/azuredevops_provider.py

<li>Updated the <code>status</code> parameter in <code>CommentThread</code> from 5 to 1.<br> <li> Ensures qodo agent comments are marked as "Active" by default.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1636/files#diff-1a90ea92bcfba3cf9f1dbc298d2e570566f4c439cb3650ee746cebdb02ca4a0b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>