### PR TITLE
doc: Add info about ollama context length

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -54,6 +54,10 @@ duplicate_examples=true # will duplicate the examples in the prompt, to help the
 api_base = "http://localhost:11434" # or whatever port you're running Ollama on
 ```
 
+By default, Ollama uses a context window size of 2048 tokens. In most cases this is not enough to cover pr-agent promt and pull-request diff. Context window size can be overridden with the `OLLAMA_CONTEXT_LENGTH` environment variable. For example, to set the default context length to 8K, use: `OLLAMA_CONTEXT_LENGTH=8192 ollama serve`. More information you can find on the [official ollama faq](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-specify-the-context-window-size).
+
+Please note that the `custom_model_max_tokens` setting should be configured in accordance with the `OLLAMA_CONTEXT_LENGTH`. Failure to do so may result in unexpected model output.
+
 !!! note "Local models vs commercial models"
     Qodo Merge is compatible with almost any AI model, but analyzing complex code repositories and pull requests requires a model specifically optimized for code analysis.
     


### PR DESCRIPTION
### **User description**
Hi!

Inspired with #1623, I've added info to the documentation how to correctly set up ollama.


___

### **PR Type**
Documentation


___

### **Description**
- Added documentation on configuring Ollama context length.

- Explained the importance of `OLLAMA_CONTEXT_LENGTH` environment variable.

- Highlighted compatibility considerations for local vs commercial models.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>changing_a_model.md</strong><dd><code>Document Ollama context length and configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/usage-guide/changing_a_model.md

<li>Added details about Ollama's default context window size.<br> <li> Provided instructions for overriding context length using <br><code>OLLAMA_CONTEXT_LENGTH</code>.<br> <li> Included a note on aligning <code>custom_model_max_tokens</code> with context <br>length.<br> <li> Added a note on compatibility of local vs commercial models.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1637/files#diff-7904af6a8722d533e7de626761ae6c1d9554069ed02634c3b719d2e7f8b39f4d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>