### PR TITLE
Bugfix: Incorrect git url in case of GitHub app

### DIFF
--- a/pr_agent/git_providers/github_provider.py
+++ b/pr_agent/git_providers/github_provider.py
@@ -82,11 +82,11 @@ class GithubProvider(GitProvider):
             return ""
 
     def get_git_repo_url(self, issues_or_pr_url: str) -> str:
-        repo_path = self._get_owner_and_repo_path(issues_or_pr_url)
+        repo_path = self._get_owner_and_repo_path(issues_or_pr_url) #Return: <OWNER>/<REPO>
         if not repo_path or repo_path not in issues_or_pr_url:
             get_logger().error(f"Unable to retrieve owner/path from url: {issues_or_pr_url}")
             return ""
-        return f"{issues_or_pr_url.split(repo_path)[0]}{repo_path}.git"
+        return f"{self.base_url_html}/{repo_path}.git" #https://github.com / <OWNER>/<REPO>.git
 
     # Given a git repo url, return prefix and suffix of the provider in order to view a given file belonging to that repo.
     # Example: https://github.com/qodo-ai/pr-agent.git and branch: v0.8 -> prefix: "https://github.com/qodo-ai/pr-agent/blob/v0.8", suffix: ""
@@ -109,7 +109,7 @@ class GithubProvider(GitProvider):
             owner, repo = self.repo.split('/')
             scheme_and_netloc = self.base_url_html
             desired_branch = self.get_pr_branch()
-        if not any([scheme_and_netloc, owner, repo]): #"else": Not invoked from a PR context,but no provided git url for context
+        if not all([scheme_and_netloc, owner, repo]): #"else": Not invoked from a PR context,but no provided git url for context
             get_logger().error(f"Unable to get canonical url parts since missing context (PR or explicit git url)")
             return ("", "")
 


### PR DESCRIPTION
### **User description**
Fix incorrect parsing when PR/issue url is from Github app context, so: https://api.github.com/repos/Codium-ai/pr-agent/issues/123 would have generated the incorrect git repo: https://api.github.com/repos/Codium-ai/pr-agent.git instead of https://github.com/Codium-ai/pr-agent.git


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect Git URL generation for GitHub app context.

- Ensure consistent URL formatting for both user and app contexts.

- Improve error handling for invalid or missing URL components.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_provider.py</strong><dd><code>Fix Git URL generation and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/github_provider.py

<li>Corrected Git URL generation logic to use <code>base_url_html</code>.<br> <li> Updated logic to ensure proper URL formatting for GitHub app context.<br> <li> Fixed condition checks for missing context in canonical URL parts.<br> <li> Improved error logging for invalid or missing URL components.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1647/files#diff-28979ec713529d6f619bcba0b9e6a3002d1164d47c70ccfea7f15306618a1a11">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>