### PR TITLE
Tr/more protections gitlab

### DIFF
--- a/pr_agent/git_providers/gitlab_provider.py
+++ b/pr_agent/git_providers/gitlab_provider.py
@@ -515,7 +515,8 @@ class GitLabProvider(GitProvider):
 
     def get_repo_settings(self):
         try:
-            contents = self.gl.projects.get(self.id_project).files.get(file_path='.pr_agent.toml', ref=self.mr.target_branch).decode()
+            main_branch = self.gl.projects.get(self.id_project).default_branch
+            contents = self.gl.projects.get(self.id_project).files.get(file_path='.pr_agent.toml', ref=main_branch).decode()
             return contents
         except Exception:
             return ""

--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -116,13 +116,14 @@ class PRQuestions:
                 model=model, temperature=get_settings().config.temperature, system=system_prompt, user=user_prompt)
         return response
 
-    def gitlab_protctions(self, model_answer: str) -> str:
+    def gitlab_protections(self, model_answer: str) -> str:
         github_quick_actions_MR = ["/approve", "/close", "/merge", "/reopen", "/unapprove", "/title", "/assign",
                                 "/copy_metadata", "/target_branch"]
         if any(action in model_answer for action in github_quick_actions_MR):
             str_err = "Model answer contains GitHub quick actions, which are not supported in GitLab"
             get_logger().error(str_err)
             return str_err
+        return model_answer
 
     def _prepare_pr_answer(self) -> str:
         model_answer = self.prediction.strip()
@@ -130,7 +131,7 @@ class PRQuestions:
         model_answer_sanitized = model_answer.replace("\n/", "\n /")
         model_answer_sanitized = model_answer_sanitized.replace("\r/", "\r /")
         if isinstance(self.git_provider, GitLabProvider):
-            model_answer_sanitized = self.gitlab_protctions(model_answer_sanitized)
+            model_answer_sanitized = self.gitlab_protections(model_answer_sanitized)
         if model_answer_sanitized.startswith("/"):
             model_answer_sanitized = " " + model_answer_sanitized
         if model_answer_sanitized != model_answer:

--- a/pr_agent/tools/pr_questions.py
+++ b/pr_agent/tools/pr_questions.py
@@ -9,7 +9,7 @@ from pr_agent.algo.pr_processing import get_pr_diff, retry_with_fallback_models
 from pr_agent.algo.token_handler import TokenHandler
 from pr_agent.algo.utils import ModelType
 from pr_agent.config_loader import get_settings
-from pr_agent.git_providers import get_git_provider
+from pr_agent.git_providers import get_git_provider, GitLabProvider
 from pr_agent.git_providers.git_provider import get_main_pr_language
 from pr_agent.log import get_logger
 from pr_agent.servers.help import HelpMessage
@@ -116,10 +116,21 @@ class PRQuestions:
                 model=model, temperature=get_settings().config.temperature, system=system_prompt, user=user_prompt)
         return response
 
+    def gitlab_protctions(self, model_answer: str) -> str:
+        github_quick_actions_MR = ["/approve", "/close", "/merge", "/reopen", "/unapprove", "/title", "/assign",
+                                "/copy_metadata", "/target_branch"]
+        if any(action in model_answer for action in github_quick_actions_MR):
+            str_err = "Model answer contains GitHub quick actions, which are not supported in GitLab"
+            get_logger().error(str_err)
+            return str_err
+
     def _prepare_pr_answer(self) -> str:
         model_answer = self.prediction.strip()
         # sanitize the answer so that no line will start with "/"
         model_answer_sanitized = model_answer.replace("\n/", "\n /")
+        model_answer_sanitized = model_answer_sanitized.replace("\r/", "\r /")
+        if isinstance(self.git_provider, GitLabProvider):
+            model_answer_sanitized = self.gitlab_protctions(model_answer_sanitized)
         if model_answer_sanitized.startswith("/"):
             model_answer_sanitized = " " + model_answer_sanitized
         if model_answer_sanitized != model_answer:


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed GitLab provider to use the default branch for repo settings.

- Added protections to prevent GitHub quick actions in GitLab PR questions.

- Enhanced PR answer sanitization for GitLab compatibility.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab_provider.py</strong><dd><code>Use default branch for GitLab repo settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/gitlab_provider.py

<li>Changed to use the default branch instead of the target branch.<br> <li> Improved repository settings retrieval logic.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1662/files#diff-35acba7a2829983fcf3c3c6a69b135988227e503ccdfa94366d1b48fcbbb0a31">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_questions.py</strong><dd><code>Add GitLab protections and improve answer sanitization</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_questions.py

<li>Added a method to detect and block GitHub quick actions in GitLab.<br> <li> Enhanced PR answer sanitization for GitLab-specific protections.<br> <li> Updated imports to include <code>GitLabProvider</code>.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1662/files#diff-71970fafa37a18dfb27eb7b47754bfa7841e14686b181445298f914e03fc31aa">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>