### PR TITLE
fix: add error handling for missing review data in PR reviewer

### DIFF
--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -229,6 +229,10 @@ class PRReviewer:
                          first_key=first_key, last_key=last_key)
         github_action_output(data, 'review')
 
+        if 'review' not in data:
+            get_logger().exception("Failed to parse review data", artifact={"data": data})
+            return ""
+
         # move data['review'] 'key_issues_to_review' key to the end of the dictionary
         if 'key_issues_to_review' in data['review']:
             key_issues_to_review = data['review'].pop('key_issues_to_review')


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added error handling for missing 'review' key in PR review data.

- Logged exception details when 'review' key is absent.

- Ensured graceful return with an empty string on error.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer.py</strong><dd><code>Added error handling for missing 'review' key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_reviewer.py

<li>Added a check for the presence of the 'review' key in parsed data.<br> <li> Logged an exception with artifact details if 'review' key is missing.<br> <li> Returned an empty string when 'review' data is absent.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1671/files#diff-8e265068e189a06852605cc694b03e92b523b4f8162077a2f3455ced4cdad8dc">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>