### PR TITLE
Correct the tools guide link in the locally installation doc

### DIFF
--- a/docs/docs/installation/locally.md
+++ b/docs/docs/installation/locally.md
@@ -6,7 +6,7 @@ To run PR-Agent locally, you first need to acquire two keys:
 
 ## Using Docker image
 
-A list of the relevant tools can be found in the [tools guide](../tools/ask.md).
+A list of the relevant tools can be found in the [tools guide](../tools/).
 
 To invoke a tool (for example `review`), you can run PR-Agent directly from the Docker image. Here's how:
 


### PR DESCRIPTION
### **User description**
It should point to the tool list, not just a specific one.

Summary from GitHub Copilot just FYR:

---

> This pull request includes a small change to the `docs/docs/installation/locally.md` file. The change updates the link to the tools guide to point to the correct directory.
> 
> Documentation update:
> 
> * [`docs/docs/installation/locally.md`](diffhunk://#diff-eb5faafeb31ee35a5ac52ada7f6449d0bd142b3be46df74262c0490190b43481L9-R9): Updated the link to the tools guide from `../tools/ask.md` to `../tools/`.


___

### **PR Type**
Documentation


___

### **Description**
- Updated the tools guide link in the local installation documentation.

- Corrected the link to point to the tools directory instead of a specific file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>locally.md</strong><dd><code>Corrected tools guide link in installation documentation</code>&nbsp; </dd></summary>
<hr>

docs/docs/installation/locally.md

<li>Updated the tools guide link.<br> <li> Changed the link from a specific file to the tools directory.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1692/files#diff-eb5faafeb31ee35a5ac52ada7f6449d0bd142b3be46df74262c0490190b43481">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>