### PR TITLE
docs: updated bitbucket pipeline docs 

### DIFF
--- a/docs/docs/installation/bitbucket.md
+++ b/docs/docs/installation/bitbucket.md
@@ -6,22 +6,21 @@ You can use the Bitbucket Pipeline system to run PR-Agent on every pull request 
 
 ```yaml
 pipelines:
-  pull-requests:
-    "**":
-      - step:
-          name: PR Agent Review
-          image: python:3.12
-          services:
-            - docker
-          script:
-            - docker run -e CONFIG.GIT_PROVIDER=bitbucket -e OPENAI.KEY=$OPENAI_API_KEY -e BITBUCKET.BEARER_TOKEN=$BITBUCKET_BEARER_TOKEN codiumai/pr-agent:latest --pr_url=https://bitbucket.org/$BITBUCKET_WORKSPACE/$BITBUCKET_REPO_SLUG/pull-requests/$BITBUCKET_PR_ID review
+    pull-requests:
+      '**':
+        - step:
+            name: PR Agent Review
+            image: codiumai/pr-agent:latest
+            script:
+              - pr-agent --pr_url=https://bitbucket.org/$BITBUCKET_WORKSPACE/$BITBUCKET_REPO_SLUG/pull-requests/$BITBUCKET_PR_ID review
 ```
 
 2. Add the following secure variables to your repository under Repository settings > Pipelines > Repository variables.
-   OPENAI_API_KEY: `<your key>`
-   BITBUCKET.AUTH_TYPE: `basic` or `bearer` (default is `bearer`)
-   BITBUCKET.BEARER_TOKEN: `<your token>` (required when auth_type is bearer)
-   BITBUCKET.BASIC_TOKEN: `<your token>` (required when auth_type is basic)
+   CONFIG__GIT_PROVIDER: `bitbucket`
+   OPENAI__KEY: `<your key>`
+   BITBUCKET__AUTH_TYPE: `basic` or `bearer` (default is `bearer`)
+   BITBUCKET__BEARER_TOKEN: `<your token>` (required when auth_type is bearer)
+   BITBUCKET__BASIC_TOKEN: `<your token>` (required when auth_type is basic)
 
 You can get a Bitbucket token for your repository by following Repository Settings -> Security -> Access Tokens.
 For basic auth, you can generate a base64 encoded token from your username:password combination.


### PR DESCRIPTION
### **User description**
Updating the Bitbucket pipeline docs to use the pr-agent image in the pipeline step instead of the current Docker in Docker setup.
This requires the Bitbucket Repository variables to make use of the double underscore notation instead of the dot notation.

This is related to the issue https://github.com/qodo-ai/pr-agent/issues/1695.


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Updated Bitbucket pipeline documentation for simplified setup.

- Replaced dot notation with double underscore in environment variables.

- Removed Docker in Docker setup from pipeline example.

- Improved clarity and usability of PR-Agent configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket.md</strong><dd><code>Simplified Bitbucket pipeline setup and variable notation</code></dd></summary>
<hr>

docs/docs/installation/bitbucket.md

<li>Updated pipeline example to remove Docker in Docker setup.<br> <li> Replaced dot notation with double underscore for environment <br>variables.<br> <li> Adjusted secure variable instructions for new notation.<br> <li> Enhanced documentation clarity and usability.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1703/files#diff-bb2c864cbe3b39ef39e1470309b83d1bc04b341d83c3d08bab96953c82e5a671">+12/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>