### PR TITLE
Add .venv/ to .dockerignore and .gitignore for virtual env compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.venv/
 venv/
 pr_agent/settings/.secrets.toml
 pics/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .lsp/
 .vscode/
 .env
+.venv/
 venv/
 pr_agent/settings/.secrets.toml
 __pycache__


### PR DESCRIPTION
Include .venv/ alongside venv/ to align with common Python virtual environment practices as recommended in the official documentation.