### PR TITLE
Fix error about load_yaml when ai response has \\n

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -705,7 +705,7 @@ def _fix_key_value(key: str, value: str):
 
 def load_yaml(response_text: str, keys_fix_yaml: List[str] = [], first_key="", last_key="") -> dict:
     response_text_original = copy.deepcopy(response_text)
-    response_text = response_text.strip('\n').removeprefix('```yaml').rstrip().removesuffix('```')
+    response_text = response_text.replace('\\n', '\n').strip('\n').removeprefix('```yaml').rstrip().removesuffix('```')
     try:
         data = yaml.safe_load(response_text)
     except Exception as e:


### PR DESCRIPTION
### **User description**
when use pr-agent to review code in gitlab by gitlab-runner, met a problem.
The ai model is DeepSeek-V3(update20250324)
![image](https://github.com/user-attachments/assets/190a3545-0ef1-4f12-a666-bb06ed1600f8)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes YAML parsing error when AI response contains escaped newlines

- Replaces all `\n` strings with actual newlines before parsing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Handle escaped newlines in YAML AI response parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/utils.py

<li>Adds replacement of <code>\n</code> with actual newlines in <code>load_yaml</code><br> <li> Ensures AI responses with escaped newlines are parsed correctly


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1717/files#diff-6b9df72d53c6f0d89fb142c210238a276c0782305e0024d16fbfcaf72c2e2b53">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>