### PR TITLE
Fix type hint for get_pr_description method and clean up whitespace

### DIFF
--- a/pr_agent/git_providers/git_provider.py
+++ b/pr_agent/git_providers/git_provider.py
@@ -133,7 +133,7 @@ class GitProvider(ABC):
     def reply_to_comment_from_comment_id(self, comment_id: int, body: str):
         pass
 
-    def get_pr_description(self, full: bool = True, split_changes_walkthrough=False) -> str or tuple:
+    def get_pr_description(self, full: bool = True, split_changes_walkthrough=False) -> str | tuple:
         from pr_agent.algo.utils import clip_tokens
         from pr_agent.config_loader import get_settings
         max_tokens_description = get_settings().get("CONFIG.MAX_DESCRIPTION_TOKENS", None)
@@ -285,7 +285,7 @@ class GitProvider(ABC):
 
     def get_comment_url(self, comment) -> str:
         return ""
-           
+
     def get_review_thread_comments(self, comment_id: int) -> list[dict]:
         pass
 


### PR DESCRIPTION
### **User description**
Binary operators are not allowed in type expressions `Pylance reportInvalidTypeForm`

In Python type annotations, to express "possibly multiple types," you cannot use or; instead, use Union or | in Python 3.10+.

**PEP 604** — Allow writing union types as X | Y.


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected type hint for `get_pr_description` method.

- Updated type annotation to use Python 3.10+ union syntax.

- Cleaned up whitespace in the file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git_provider.py</strong><dd><code>Update type hint and clean whitespace in git_provider.py</code>&nbsp; </dd></summary>
<hr>

pr_agent/git_providers/git_provider.py

<li>Changed type hint for <code>get_pr_description</code> to use <code>str | tuple</code>.<br> <li> Removed legacy type hint syntax (<code>str or tuple</code>).<br> <li> Cleaned up whitespace in the file.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1728/files#diff-52d45f12b836f77ed1aef86e972e65404634ea4e2a6083fb71a9b0f9bb9e062f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>