### PR TITLE
docs: update Gemini model path from google_ai_studio to gemini in con…

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -172,8 +172,8 @@ To use [Google AI Studio](https://aistudio.google.com/) models, set the relevant
 
 ```toml
 [config] # in configuration.toml
-model="google_ai_studio/gemini-1.5-flash"
-fallback_models=["google_ai_studio/gemini-1.5-flash"]
+model="gemini/gemini-1.5-flash"
+fallback_models=["gemini/gemini-1.5-flash"]
 
 [google_ai_studio] # in .secrets.toml
 gemini_api_key = "..."


### PR DESCRIPTION
### **User description**
This PR addresses the following improvements related to [issue #1730](https://github.com/qodo-ai/pr-agent/issues/1730):

1. Documentation Update:

- Corrects the Gemini provider name for LiteLLM from google_ai_studio to gemini in the usage guide (docs/docs/usage-guide/changing_a_model.md), ensuring consistency with the actual provider key used in code and LiteLLM documentation.

Motivation
- The previous documentation referenced an outdated provider name, which could cause confusion for users integrating Gemini models via LiteLLM.


___

### **PR Type**
Documentation


___

### **Description**
- Update Gemini provider name in usage guide documentation

- Replace outdated `google_ai_studio` with correct `gemini` path

- Ensure configuration examples match LiteLLM and code usage


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>changing_a_model.md</strong><dd><code>Correct Gemini provider path in configuration documentation</code></dd></summary>
<hr>

docs/docs/usage-guide/changing_a_model.md

<li>Changed configuration examples to use <code>gemini/gemini-1.5-flash</code> instead <br>of <code>google_ai_studio/gemini-1.5-flash</code><br> <li> Updated both <code>model</code> and <code>fallback_models</code> example lines for accuracy<br> <li> Ensured documentation aligns with actual provider key in code and <br>LiteLLM docs


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1731/files#diff-7904af6a8722d533e7de626761ae6c1d9554069ed02634c3b719d2e7f8b39f4d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>