### PR TITLE
Add ignore_repositories config for PR filtering

### DIFF
--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -258,6 +258,14 @@ def should_process_pr_logic(body) -> bool:
         source_branch = pull_request.get("head", {}).get("ref", "")
         target_branch = pull_request.get("base", {}).get("ref", "")
         sender = body.get("sender", {}).get("login")
+        repo_full_name = body.get("repository", {}).get("full_name", "")
+
+        # logic to ignore PRs from specific repositories
+        ignore_repos = get_settings().get("CONFIG.IGNORE_REPOSITORIES", [])
+        if ignore_repos and repo_full_name:
+            if repo_full_name in ignore_repos:
+                get_logger().info(f"Ignoring PR from repository '{repo_full_name}' due to 'config.ignore_repositories' setting")
+                return False
 
         # logic to ignore PRs from specific users
         ignore_pr_users = get_settings().get("CONFIG.IGNORE_PR_AUTHORS", [])

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -103,6 +103,14 @@ def should_process_pr_logic(data) -> bool:
             return False
         title = data['object_attributes'].get('title')
         sender = data.get("user", {}).get("username", "")
+        repo_full_name = data.get('project', {}).get('path_with_namespace', "")
+
+        # logic to ignore PRs from specific repositories
+        ignore_repos = get_settings().get("CONFIG.IGNORE_REPOSITORIES", [])
+        if ignore_repos and repo_full_name:
+            if repo_full_name in ignore_repos:
+                get_logger().info(f"Ignoring MR from repository '{repo_full_name}' due to 'config.ignore_repositories' setting")
+                return False
 
         # logic to ignore PRs from specific users
         ignore_pr_users = get_settings().get("CONFIG.IGNORE_PR_AUTHORS", [])

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -55,6 +55,7 @@ ignore_pr_target_branches = [] # a list of regular expressions of target branche
 ignore_pr_source_branches = [] # a list of regular expressions of source branches to ignore from PR agent when an PR is created
 ignore_pr_labels = [] # labels to ignore from PR agent when an PR is created
 ignore_pr_authors = [] # authors to ignore from PR agent when an PR is created
+ignore_repositories = [] # list of repository full names (e.g. "org/repo") to ignore from PR agent processing
 #
 is_auto_command = false # will be auto-set to true if the command is triggered by an automation
 enable_ai_metadata = false # will enable adding ai metadata

--- a/tests/unittest/test_ignore_repositories.py
+++ b/tests/unittest/test_ignore_repositories.py
@@ -1,0 +1,79 @@
+import pytest
+from pr_agent.servers.github_app import should_process_pr_logic as github_should_process_pr_logic
+from pr_agent.servers.bitbucket_app import should_process_pr_logic as bitbucket_should_process_pr_logic
+from pr_agent.servers.gitlab_webhook import should_process_pr_logic as gitlab_should_process_pr_logic
+from pr_agent.config_loader import get_settings
+
+def make_bitbucket_payload(full_name):
+    return {
+        "data": {
+            "pullrequest": {
+                "title": "Test PR",
+                "source": {"branch": {"name": "feature/test"}},
+                "destination": {
+                    "branch": {"name": "main"},
+                    "repository": {"full_name": full_name}
+                }
+            },
+            "actor": {"username": "user", "type": "user"}
+        }
+    }
+
+def make_github_body(full_name):
+    return {
+        "pull_request": {},
+        "repository": {"full_name": full_name},
+        "sender": {"login": "user"}
+    }
+
+def make_gitlab_body(full_name):
+    return {
+        "object_attributes": {"title": "Test MR"},
+        "project": {"path_with_namespace": full_name}
+    }
+
+PROVIDERS = [
+    ("github", github_should_process_pr_logic, make_github_body),
+    ("bitbucket", bitbucket_should_process_pr_logic, make_bitbucket_payload),
+    ("gitlab", gitlab_should_process_pr_logic, make_gitlab_body),
+]
+
+class TestIgnoreRepositories:
+    def setup_method(self):
+        get_settings().set("CONFIG.IGNORE_REPOSITORIES", [])
+
+    @pytest.mark.parametrize("provider_name, provider_func, body_func", PROVIDERS)
+    def test_should_ignore_matching_repository(self, provider_name, provider_func, body_func):
+        get_settings().set("CONFIG.IGNORE_REPOSITORIES", ["org/repo-to-ignore"])
+        body = {
+            "pull_request": {},
+            "repository": {"full_name": "org/repo-to-ignore"},
+            "sender": {"login": "user"}
+        }
+        result = provider_func(body_func(body["repository"]["full_name"]))
+        print(f"DEBUG: Provider={provider_name}, test_should_ignore_matching_repository, result={result}")
+        assert result is False, f"{provider_name}: PR from ignored repository should be ignored (return False)"
+
+    @pytest.mark.parametrize("provider_name, provider_func, body_func", PROVIDERS)
+    def test_should_not_ignore_non_matching_repository(self, provider_name, provider_func, body_func):
+        get_settings().set("CONFIG.IGNORE_REPOSITORIES", ["org/repo-to-ignore"])
+        body = {
+            "pull_request": {},
+            "repository": {"full_name": "org/other-repo"},
+            "sender": {"login": "user"}
+        }
+        result = provider_func(body_func(body["repository"]["full_name"]))
+        print(f"DEBUG: Provider={provider_name}, test_should_not_ignore_non_matching_repository, result={result}")
+        assert result is True, f"{provider_name}: PR from non-ignored repository should not be ignored (return True)"
+
+    @pytest.mark.parametrize("provider_name, provider_func, body_func", PROVIDERS)
+    def test_should_not_ignore_when_config_empty(self, provider_name, provider_func, body_func):
+        get_settings().set("CONFIG.IGNORE_REPOSITORIES", [])
+        body = {
+            "pull_request": {},
+            "repository": {"full_name": "org/repo-to-ignore"},
+            "sender": {"login": "user"}
+        }
+        result = provider_func(body_func(body["repository"]["full_name"]))
+        print(f"DEBUG: Provider={provider_name}, test_should_not_ignore_when_config_empty, result={result}")
+        assert result is True, f"{provider_name}: PR should not be ignored if ignore_repositories config is empty" 


### PR DESCRIPTION
### **User description**
We want to enable the pr-agent for hundreds of projects in our organization, and then exclude a handful of repos from being reviewed. Given there seems to be no current solution for that, this option has been added here.

What Changed?
* Added support to ignore PRs/MRs from specific repositories in GitHub, Bitbucket, and GitLab webhook logic
* Updated configuration.toml to include ignore_repositories option
* Added unit tests for ignore_repositories across all supported providers


___

### **PR Type**
enhancement, tests


___

### **Description**
- Added `ignore_repositories` config to filter PRs/MRs by repository.
  - Implemented in GitHub, Bitbucket, and GitLab webhook logic.
  - Skips processing for PRs/MRs from listed repositories.

- Updated configuration documentation to include `ignore_repositories`.

- Added comprehensive unit tests for repository ignore logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket_app.py</strong><dd><code>Add repository ignore logic and debug logging for Bitbucket</code></dd></summary>
<hr>

pr_agent/servers/bitbucket_app.py

<li>Added logic to skip PRs from repositories in <code>ignore_repositories</code>.<br> <li> Added debug and info logging for repository filtering.<br> <li> Improved debug output for other ignore conditions.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1736/files#diff-963a9de391ff22ad3083c3a28c1d5736d68a6e1e40b0bedb52d4bfd124325bad">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>github_app.py</strong><dd><code>Add repository ignore logic for GitHub PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/github_app.py

<li>Added logic to skip PRs from repositories in <code>ignore_repositories</code>.<br> <li> Added info logging for repository filtering.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1736/files#diff-3fb3f174152732d1b69953c8bd81b8a0a30f0e42100dc626d932da8371851608">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gitlab_webhook.py</strong><dd><code>Add repository ignore logic for GitLab MRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/gitlab_webhook.py

<li>Added logic to skip MRs from repositories in <code>ignore_repositories</code>.<br> <li> Added info logging for repository filtering.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1736/files#diff-c3ea1ba460930c6e6e6a2c36a7dc729d79730a96e872d40ffb246f80bc7c0880">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Document ignore_repositories config option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml

- Documented new `ignore_repositories` config option.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1736/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ignore_repositories.py</strong><dd><code>Add tests for repository ignore filtering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_ignore_repositories.py

<li>Added unit tests for <code>ignore_repositories</code> logic across all providers.<br> <li> Tests both matching and non-matching repository scenarios.<br> <li> Tests behavior when config is empty.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1736/files#diff-c101037e76d8d880e1b557c3815cd72de78f22847023bc896fdcd5c2110d2300">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>