### PR TITLE
Azure devops: parse PR url starting from the end

### DIFF
--- a/tests/unittest/test_azure_devops_parsing.py
+++ b/tests/unittest/test_azure_devops_parsing.py
@@ -13,3 +13,10 @@ class TestAzureDevOpsParsing():
 
         # workspace_slug, repo_slug, pr_number
         assert AzureDevopsProvider._parse_pr_url(pr_url) == ("project", "repo", 1)
+        
+    def test_self_hosted_address(self):
+        pr_url = "http://server.be:8080/tfs/department/project/_git/repo/pullrequest/1"
+
+        # workspace_slug, repo_slug, pr_number
+        assert AzureDevopsProvider._parse_pr_url(pr_url) == ("project", "repo", 1)
+


### PR DESCRIPTION
### **User description**
My company uses a self-hosted AzureDevops server.
The path has more parts than the public Azure PR urls: `http://server:1234/tfs/$department/$project/_git/$repo/pullrequest/68407`
I modified the url parser to count the parts from the end of the url, this way it works for any prefix.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improved Azure DevOps PR URL parsing for flexible path structures

- Replaced fixed-length parsing with end-based indexing for robustness

- Enhanced error handling for malformed or unexpected URLs


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_provider.py</strong><dd><code>Flexible and robust Azure DevOps PR URL parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/azuredevops_provider.py

<li>Replaced fixed-length path parsing with end-based indexing for PR URLs<br> <li> Improved compatibility with self-hosted and custom Azure DevOps server <br>URLs<br> <li> Enhanced error handling for invalid or unexpected URL formats


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1742/files#diff-1a90ea92bcfba3cf9f1dbc298d2e570566f4c439cb3650ee746cebdb02ca4a0b">+7/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>