### PR TITLE
fix: Prevent duplicate language instructions in extra_instructions

### DIFF
--- a/pr_agent/agent/pr_agent.py
+++ b/pr_agent/agent/pr_agent.py
@@ -84,10 +84,18 @@ class PRAgent:
                 if str(type(setting)) == "<class 'dynaconf.utils.boxing.DynaBox'>":
                     if hasattr(setting, 'extra_instructions'):
                         current_extra_instructions = setting.extra_instructions
-                        if current_extra_instructions:
-                            setting.extra_instructions = current_extra_instructions+ f"\n======\n\nIn addition, Your response MUST be written in the language corresponding to local code: {response_language}. This is crucial."
-                        else:
-                            setting.extra_instructions = f"Your response MUST be written in the language corresponding to locale code: '{response_language}'. This is crucial."
+                        
+                        # Define the language-specific instruction and the separator
+                        lang_instruction_text = f"Your response MUST be written in the language corresponding to locale code: '{response_language}'. This is crucial."
+                        separator_text = "\n======\n\nIn addition, "
+
+                        # Check if the specific language instruction is already present to avoid duplication
+                        if lang_instruction_text not in str(current_extra_instructions):
+                            if current_extra_instructions: # If there's existing text
+                                setting.extra_instructions = str(current_extra_instructions) + separator_text + lang_instruction_text
+                            else: # If extra_instructions was None or empty
+                                setting.extra_instructions = lang_instruction_text
+                        # If lang_instruction_text is already present, do nothing.
 
         action = action.lstrip("/").lower()
         if action not in command2class:


### PR DESCRIPTION
### **User description**
Currently, when processing a non-default response_language, it appends a language-specific directive to the extra_instructions in the settings. However, if this occurs multiple times (e.g., there are [3 commands](https://github.com/qodo-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L269) when serving as gitlab webhook server ), the directive is duplicated, leading to an unnecessarily long instruction string in system prompts. 

below are traces that we catch in langfuse: 
- system prompt in /describe
![image](https://github.com/user-attachments/assets/dd0464d3-204d-45d2-96ac-04d65aa77892)


- system prompt in /review
![image](https://github.com/user-attachments/assets/632d5fa6-b931-43b8-8a41-865a826be6a7)


- system prompt in /improve
![image](https://github.com/user-attachments/assets/a57fc345-2370-4257-ae42-f4e541dcd93d)


___

### **PR Type**
Bug fix


___

### **Description**
- Prevents duplicate language instructions in `extra_instructions`

- Adds check before appending language directive to settings

- Refines logic for appending language-specific instructions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_agent.py</strong><dd><code>Prevent duplicate language instruction in settings extra_instructions</code></dd></summary>
<hr>

pr_agent/agent/pr_agent.py

<li>Adds logic to check for existing language instruction before appending<br> <li> Prevents duplication of language-specific directive in <br><code>extra_instructions</code><br> <li> Refactors string concatenation for clarity and correctness


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1745/files#diff-db2b038f914c88e292869242ae3c293765511994a83d72459642e81b5b741f47">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>