### PR TITLE
fix(gitlab): trigger when MR changes from draft to ready

### DIFF
--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -86,9 +86,19 @@ def is_draft(data) -> bool:
 def is_draft_ready(data) -> bool:
     try:
         if 'draft' in data.get('changes', {}):
-            if data['changes']['draft']['previous'] == 'true' and data['changes']['draft']['current'] == 'false':
+            # Handle both boolean values and string values for compatibility
+            previous = data['changes']['draft']['previous']
+            current = data['changes']['draft']['current']
+
+            # Convert to boolean if they're strings
+            if isinstance(previous, str):
+                previous = previous.lower() == 'true'
+            if isinstance(current, str):
+                current = current.lower() == 'true'
+
+            if previous is True and current is False:
                 return True
-            
+
         # for gitlab server version before 16
         elif 'title' in data.get('changes', {}):
             if 'Draft:' in data['changes']['title']['previous'] and 'Draft:' not in data['changes']['title']['current']:


### PR DESCRIPTION
### **User description**
It currently isn't retriggering when the MR goes from draft to ready. The main issue is in the `is_draft_ready` function which doesn't correctly handle the webhook data format coming from GitLab:

```json
{
  "changes": {
    "draft": {
      "previous": true,
      "current": false
    },
  },
}
```

The problem is that the function is comparing string values 'true' and 'false', but in the webhook data, the values are booleans. In my PR, it converts string values to boolean if needed for compatibility with different GitLab versions and uses strict type comparison (is True and is False) to ensure correct behavior.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes detection of draft-to-ready state in GitLab MRs

- Adds compatibility for both boolean and string webhook values

- Ensures strict type comparison for draft status changes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab_webhook.py</strong><dd><code>Improve MR draft-to-ready detection for GitLab webhooks</code>&nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/gitlab_webhook.py

<li>Updates <code>is_draft_ready</code> to handle both boolean and string values<br> <li> Converts string values to booleans for compatibility<br> <li> Uses strict type comparison for draft status detection


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1749/files#diff-c3ea1ba460930c6e6e6a2c36a7dc729d79730a96e872d40ffb246f80bc7c0880">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>