### PR TITLE
fix:correct typo in logger parameter from 'artifacts' to 'artifact'

### DIFF
--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -95,7 +95,7 @@ class PRDescription:
             get_logger().info(f"Generating a PR description for pr_id: {self.pr_id}")
             relevant_configs = {'pr_description': dict(get_settings().pr_description),
                                 'config': dict(get_settings().config)}
-            get_logger().debug("Relevant configs", artifacts=relevant_configs)
+            get_logger().debug("Relevant configs", artifact=relevant_configs)
             if get_settings().config.publish_output and not get_settings().config.get('is_auto_command', False):
                 self.git_provider.publish_comment("Preparing PR description...", is_temporary=True)
 


### PR DESCRIPTION
### **User description**
[The original PR](https://github.com/qodo-ai/pr-agent/pull/1747) was rejected due to formatting changes, so I submitted a new one. 
I think this was caused by the auto-formatting feature in my IDE.

---

This PR fixes a minor typo in a debug logging call to ensure the logger behaves as expected.

Fixed a typo in the get_logger().debug(...) call: changed artifacts= to artifact=.
The logger expects the parameter to be named artifact, and using the wrong keyword can cause logs to be silently ignored or raise runtime errors.
This fix ensures that debugging output is correctly captured and visible during development.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed typo in logger debug call parameter name.

- Ensures correct logging of relevant configs.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description.py</strong><dd><code>Correct logger debug parameter name for configs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_description.py

<li>Changed logger debug call parameter from 'artifacts' to 'artifact'.<br> <li> Prevents potential logging issues due to incorrect parameter name.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1753/files#diff-66130451adce278a098a5770e2db52b12050205fcd4d80c13f813615d4449abb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>