### PR TITLE
fix: avoid duplicate header for list types to prevent markdown break

### DIFF
--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -507,7 +507,7 @@ class PRDescription:
         ai_type = self.data.get('type')
         if ai_type and not re.search(r'<!--\s*pr_agent:type\s*-->', body):
             if isinstance(ai_type, list):
-                pr_type = ', '.join(ai_type)
+                pr_type = ', '.join(str(t) for t in ai_type)
             else:
                 pr_type = ai_type
             pr_type = f"{ai_header}{pr_type}"

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -507,10 +507,10 @@ class PRDescription:
         ai_type = self.data.get('type')
         if ai_type and not re.search(r'<!--\s*pr_agent:type\s*-->', body):
             if isinstance(ai_type, list):
-                pr_types = [f"{ai_header}{t}" for t in ai_type]
-                pr_type = ','.join(pr_types)
+                pr_type = ', '.join(ai_type)
             else:
-                pr_type = f"{ai_header}{ai_type}"
+                pr_type = ai_type
+            pr_type = f"{ai_header}{pr_type}"
             body = body.replace('pr_agent:type', pr_type)
 
         ai_summary = self.data.get('description')


### PR DESCRIPTION
### **User description**
This PR fixes a markdown rendering issue caused by repeated headers when `type` is a list.

<img width="673" alt="Pasted Graphic 15" src="https://github.com/user-attachments/assets/609acb0e-8876-44d5-8543-633eae6fb82e" />


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes duplicate header issue for list-type PR descriptions

- Ensures markdown rendering is not broken by repeated headers


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description.py</strong><dd><code>Fix duplicate header for list-type PR descriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_description.py

<li>Refactored header insertion logic for list-type <code>type</code> fields<br> <li> Ensured header is added only once before the joined list<br> <li> Prevented markdown breakage from repeated headers


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1758/files#diff-66130451adce278a098a5770e2db52b12050205fcd4d80c13f813615d4449abb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>