### PR TITLE
docs: clarify that .pr_agent.toml can be updated post PR creation

### DIFF
--- a/docs/docs/usage-guide/configuration_options.md
+++ b/docs/docs/usage-guide/configuration_options.md
@@ -39,7 +39,7 @@ Qodo Merge will know to remove the surrounding quotes when reading the configura
 
 `Platforms supported: GitHub, GitLab, Bitbucket, Azure DevOps`
 
-By uploading a local `.pr_agent.toml` file to the root of the repo's default branch, you can edit and customize any configuration parameter. Note that you need to upload `.pr_agent.toml` prior to creating a PR, in order for the configuration to take effect.
+By uploading a local `.pr_agent.toml` file to the root of the repo's default branch, you can edit and customize any configuration parameter. Note that you need to upload or update `.pr_agent.toml` before using the PR Agent tools (either at PR creation or via manual trigger) for the configuration to take effect.
 
 For example, if you set in `.pr_agent.toml`:
 


### PR DESCRIPTION
### **User description**
This PR updates the documentation regarding the use of the .pr_agent.toml configuration file.

The previous documentation stated that _`.pr_agent.toml needs to be uploaded prior to creating a PR in order for the configuration to take effect`_. However, based on usage, changes to the configuration file can affect PR Agent behavior even after a PR is created, as long as the updated file is in place before the tool is triggered. (e.g., via a comment like /describe).

The phrasing was revised to reduce confusion by clarifying that the configuration must be in place before using PR Agent tools.


___

### **PR Type**
Documentation


___

### **Description**
- Clarifies when `.pr_agent.toml` configuration changes take effect

- Updates documentation to reduce confusion about config timing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration_options.md</strong><dd><code>Clarify `.pr_agent.toml` timing for configuration application</code></dd></summary>
<hr>

docs/docs/usage-guide/configuration_options.md

<li>Updates explanation about when <code>.pr_agent.toml</code> must be present<br> <li> Specifies config must be in place before using PR Agent tools<br> <li> Removes implication that config only applies at PR creation


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1760/files#diff-5b3d743def9f77f0b3ac72c61a3eec1418f87313b285ca3926b196828d8ecc2d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>