### PR TITLE
Changelog prompt: fix markdown link

### DIFF
--- a/pr_agent/settings/pr_update_changelog_prompts.toml
+++ b/pr_agent/settings/pr_update_changelog_prompts.toml
@@ -6,7 +6,7 @@ Your task is to add a brief summary of this PR's changes to CHANGELOG.md file of
 - Be general, and avoid specific details, files, etc. The output should be minimal, no more than 3-4 short lines.
 - Write only the new content to be added to CHANGELOG.md, without any introduction or summary. The content should appear as if it's a natural part of the existing file.
 {%- if pr_link %}
-- If relevant, convert the changelog main header into a clickable link using the PR URL '{{ pr_link }}'. Format: header [*][pr_link]
+- If relevant, convert the changelog main header into a clickable link using the PR URL '{{ pr_link }}'. Format: header [*](pr_link)
 {%- endif %}
 
 


### PR DESCRIPTION
### **User description**
There was a typo in the markdown example in the prompt


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected markdown link format in changelog prompt instructions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_update_changelog_prompts.toml</strong><dd><code>Correct markdown link syntax in changelog prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/pr_update_changelog_prompts.toml

<li>Fixed the markdown link example in the prompt instructions.<br> <li> Updated the format to use proper markdown link syntax.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1764/files#diff-747cb559f884778ef72e038de6121eb55f0e322e097f02fa27aa51e640d3c6f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>