### PR TITLE
fix: add timeout to asyncio.wait during CLI execution to avoid hanging when callback is enabled

### DIFF
--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -88,7 +88,9 @@ def run(inargs=None, args=None):
             get_logger().debug("Waiting for event queue to complete")
             tasks = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
             if tasks:
-                await asyncio.wait(tasks, timeout=30)
+                done, pending = await asyncio.wait(tasks, timeout=30)
+                if pending:
+                    get_logger().warning(f"{len(pending)} callback tasks did not complete within timeout")
 
         return result
 

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -86,7 +86,9 @@ def run(inargs=None, args=None):
         if get_settings().litellm.get("enable_callbacks", False):
             # There may be additional events on the event queue from the run above. If there are give them time to complete.
             get_logger().debug("Waiting for event queue to complete")
-            await asyncio.wait([task for task in asyncio.all_tasks() if task is not asyncio.current_task()])
+            tasks = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
+            if tasks:
+                await asyncio.wait(tasks, timeout=30)
 
         return result
 

--- a/pr_agent/cli.py
+++ b/pr_agent/cli.py
@@ -88,9 +88,11 @@ def run(inargs=None, args=None):
             get_logger().debug("Waiting for event queue to complete")
             tasks = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
             if tasks:
-                done, pending = await asyncio.wait(tasks, timeout=30)
+                _, pending = await asyncio.wait(tasks, timeout=30)
                 if pending:
-                    get_logger().warning(f"{len(pending)} callback tasks did not complete within timeout")
+                    get_logger().warning(
+                        f"{len(pending)} callback tasks({[task.get_coro() for task in pending]}) did not complete within timeout"
+                    )
 
         return result
 


### PR DESCRIPTION
### **User description**
When integrating with [logging observability platforms](https://qodo-merge-docs.qodo.ai/usage-guide/additional_configurations/?h=logging#integrating-with-logging-observability-platforms):
- **Langfuse**(==v2.60.4): I encountered an issue where the error "Set of Tasks/Futures is empty" was raised. To resolve this, I added a condition to handle that case.
<img width="560" alt="스크린샷 2025-05-13 오후 2 51 34" src="https://github.com/user-attachments/assets/cc8b41ab-8180-4ad2-812c-54955adfe4f2" />


- **Langsmith**(with litellm==v1.66.3): I experienced an infinite wait issue, which turned out to be caused by [periodic flushing](https://github.com/BerriAI/litellm/blob/95ab2cee61c3065eabec034b1ab0e8aa0a3e25ff/litellm/integrations/custom_batch_logger.py#L36). To mitigate this, I added a TTL (time-to-live) to limit the waiting time.
<img width="1234" alt="스크린샷 2025-05-13 오후 2 55 17" src="https://github.com/user-attachments/assets/f3b51fe3-3b78-47bf-a66a-76e3c18bf80a" />
<img width="551" alt="스크린샷 2025-05-13 오후 2 56 08" src="https://github.com/user-attachments/assets/f746af36-f04c-4fbc-a9ba-22f66424075f" />


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add timeout to `asyncio.wait` when callbacks are enabled
  - Prevents infinite wait by limiting to 30 seconds
  - Handles empty task set to avoid errors


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Add timeout and empty-task check to event queue wait</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/cli.py

<li>Added a 30-second timeout to <code>asyncio.wait</code> for callback tasks<br> <li> Added a check to ensure the task list is not empty before waiting<br> <li> Prevents errors and infinite waits during event queue flushing


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1770/files#diff-88577a9bac5c261b52dcec31fdf5e525cef5c6ddffdcb6bde0e9ba183fa05996">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>