### PR TITLE
Pr 1736

### DIFF
--- a/docs/docs/usage-guide/additional_configurations.md
+++ b/docs/docs/usage-guide/additional_configurations.md
@@ -164,6 +164,7 @@ Qodo Merge allows you to automatically ignore certain PRs based on various crite
 
 - PRs with specific titles (using regex matching)
 - PRs between specific branches (using regex matching)
+- PRs from specific repositories (using regex matching)
 - PRs not from specific folders
 - PRs containing specific labels
 - PRs opened by specific users
@@ -172,7 +173,7 @@ Qodo Merge allows you to automatically ignore certain PRs based on various crite
 
 To ignore PRs with a specific title such as "[Bump]: ...", you can add the following to your `configuration.toml` file:
 
-```
+```toml
 [config]
 ignore_pr_title = ["\\[Bump\\]"]
 ```
@@ -183,7 +184,7 @@ Where the `ignore_pr_title` is a list of regex patterns to match the PR title yo
 
 To ignore PRs from specific source or target branches, you can add the following to your `configuration.toml` file:
 
-```
+```toml
 [config]
 ignore_pr_source_branches = ['develop', 'main', 'master', 'stage']
 ignore_pr_target_branches = ["qa"]
@@ -191,6 +192,18 @@ ignore_pr_target_branches = ["qa"]
 
 Where the `ignore_pr_source_branches` and `ignore_pr_target_branches` are lists of regex patterns to match the source and target branches you want to ignore.
 They are not mutually exclusive, you can use them together or separately.
+
+### Ignoring PRs from specific repositories
+
+To ignore PRs from specific repositories, you can add the following to your `configuration.toml` file:
+
+```toml
+[config]
+ignore_repositories = ["my-org/my-repo1", "my-org/my-repo2"]
+```
+
+Where the `ignore_repositories` is a list of regex patterns to match the repositories you want to ignore. This is useful when you have multiple repositories and want to exclude certain ones from analysis.
+
 
 ### Ignoring PRs not from specific folders
 

--- a/pr_agent/servers/bitbucket_app.py
+++ b/pr_agent/servers/bitbucket_app.py
@@ -165,7 +165,6 @@ def should_process_pr_logic(data) -> bool:
                 return False
     except Exception as e:
         get_logger().error(f"Failed 'should_process_pr_logic': {e}")
-    print("DEBUG: Returning True from should_process_pr_logic")
     return True
 
 

--- a/pr_agent/servers/bitbucket_app.py
+++ b/pr_agent/servers/bitbucket_app.py
@@ -129,12 +129,10 @@ def should_process_pr_logic(data) -> bool:
         sender = _get_username(data)
         repo_full_name = pr_data.get("destination", {}).get("repository", {}).get("full_name", "")
 
-        print(f"DEBUG: repo_full_name={repo_full_name}, ignore_repos={get_settings().get('CONFIG.IGNORE_REPOSITORIES', [])}")
         # logic to ignore PRs from specific repositories
         ignore_repos = get_settings().get("CONFIG.IGNORE_REPOSITORIES", [])
-        if ignore_repos and repo_full_name:
-            if repo_full_name in ignore_repos:
-                print(f"DEBUG: Ignoring due to repo match: {repo_full_name}")
+        if repo_full_name and ignore_repos:
+            if any(re.search(regex, repo_full_name) for regex in ignore_repos):
                 get_logger().info(f"Ignoring PR from repository '{repo_full_name}' due to 'config.ignore_repositories' setting")
                 return False
 
@@ -142,7 +140,6 @@ def should_process_pr_logic(data) -> bool:
         ignore_pr_users = get_settings().get("CONFIG.IGNORE_PR_AUTHORS", [])
         if ignore_pr_users and sender:
             if sender in ignore_pr_users:
-                print(f"DEBUG: Ignoring due to user match: {sender}")
                 get_logger().info(f"Ignoring PR from user '{sender}' due to 'config.ignore_pr_authors' setting")
                 return False
 
@@ -152,7 +149,6 @@ def should_process_pr_logic(data) -> bool:
             if not isinstance(ignore_pr_title_re, list):
                 ignore_pr_title_re = [ignore_pr_title_re]
             if ignore_pr_title_re and any(re.search(regex, title) for regex in ignore_pr_title_re):
-                print(f"DEBUG: Ignoring due to title match: {title}")
                 get_logger().info(f"Ignoring PR with title '{title}' due to config.ignore_pr_title setting")
                 return False
 
@@ -160,17 +156,14 @@ def should_process_pr_logic(data) -> bool:
         ignore_pr_target_branches = get_settings().get("CONFIG.IGNORE_PR_TARGET_BRANCHES", [])
         if (ignore_pr_source_branches or ignore_pr_target_branches):
             if any(re.search(regex, source_branch) for regex in ignore_pr_source_branches):
-                print(f"DEBUG: Ignoring due to source branch match: {source_branch}")
                 get_logger().info(
                     f"Ignoring PR with source branch '{source_branch}' due to config.ignore_pr_source_branches settings")
                 return False
             if any(re.search(regex, target_branch) for regex in ignore_pr_target_branches):
-                print(f"DEBUG: Ignoring due to target branch match: {target_branch}")
                 get_logger().info(
                     f"Ignoring PR with target branch '{target_branch}' due to config.ignore_pr_target_branches settings")
                 return False
     except Exception as e:
-        print(f"DEBUG: Exception in should_process_pr_logic: {e}")
         get_logger().error(f"Failed 'should_process_pr_logic': {e}")
     print("DEBUG: Returning True from should_process_pr_logic")
     return True

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -263,7 +263,7 @@ def should_process_pr_logic(body) -> bool:
         # logic to ignore PRs from specific repositories
         ignore_repos = get_settings().get("CONFIG.IGNORE_REPOSITORIES", [])
         if ignore_repos and repo_full_name:
-            if repo_full_name in ignore_repos:
+            if any(re.search(regex, repo_full_name) for regex in ignore_repos):
                 get_logger().info(f"Ignoring PR from repository '{repo_full_name}' due to 'config.ignore_repositories' setting")
                 return False
 

--- a/pr_agent/servers/github_app.py
+++ b/pr_agent/servers/github_app.py
@@ -258,6 +258,14 @@ def should_process_pr_logic(body) -> bool:
         source_branch = pull_request.get("head", {}).get("ref", "")
         target_branch = pull_request.get("base", {}).get("ref", "")
         sender = body.get("sender", {}).get("login")
+        repo_full_name = body.get("repository", {}).get("full_name", "")
+
+        # logic to ignore PRs from specific repositories
+        ignore_repos = get_settings().get("CONFIG.IGNORE_REPOSITORIES", [])
+        if ignore_repos and repo_full_name:
+            if repo_full_name in ignore_repos:
+                get_logger().info(f"Ignoring PR from repository '{repo_full_name}' due to 'config.ignore_repositories' setting")
+                return False
 
         # logic to ignore PRs from specific users
         ignore_pr_users = get_settings().get("CONFIG.IGNORE_PR_AUTHORS", [])

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -103,6 +103,14 @@ def should_process_pr_logic(data) -> bool:
             return False
         title = data['object_attributes'].get('title')
         sender = data.get("user", {}).get("username", "")
+        repo_full_name = data.get('project', {}).get('path_with_namespace', "")
+
+        # logic to ignore PRs from specific repositories
+        ignore_repos = get_settings().get("CONFIG.IGNORE_REPOSITORIES", [])
+        if ignore_repos and repo_full_name:
+            if repo_full_name in ignore_repos:
+                get_logger().info(f"Ignoring MR from repository '{repo_full_name}' due to 'config.ignore_repositories' setting")
+                return False
 
         # logic to ignore PRs from specific users
         ignore_pr_users = get_settings().get("CONFIG.IGNORE_PR_AUTHORS", [])

--- a/pr_agent/servers/gitlab_webhook.py
+++ b/pr_agent/servers/gitlab_webhook.py
@@ -108,7 +108,7 @@ def should_process_pr_logic(data) -> bool:
         # logic to ignore PRs from specific repositories
         ignore_repos = get_settings().get("CONFIG.IGNORE_REPOSITORIES", [])
         if ignore_repos and repo_full_name:
-            if repo_full_name in ignore_repos:
+            if any(re.search(regex, repo_full_name) for regex in ignore_repos):
                 get_logger().info(f"Ignoring MR from repository '{repo_full_name}' due to 'config.ignore_repositories' setting")
                 return False
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -55,6 +55,7 @@ ignore_pr_target_branches = [] # a list of regular expressions of target branche
 ignore_pr_source_branches = [] # a list of regular expressions of source branches to ignore from PR agent when an PR is created
 ignore_pr_labels = [] # labels to ignore from PR agent when an PR is created
 ignore_pr_authors = [] # authors to ignore from PR agent when an PR is created
+ignore_repositories = [] # list of repository full names (e.g. "org/repo") to ignore from PR agent processing
 #
 is_auto_command = false # will be auto-set to true if the command is triggered by an automation
 enable_ai_metadata = false # will enable adding ai metadata

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -55,7 +55,7 @@ ignore_pr_target_branches = [] # a list of regular expressions of target branche
 ignore_pr_source_branches = [] # a list of regular expressions of source branches to ignore from PR agent when an PR is created
 ignore_pr_labels = [] # labels to ignore from PR agent when an PR is created
 ignore_pr_authors = [] # authors to ignore from PR agent when an PR is created
-ignore_repositories = [] # list of repository full names (e.g. "org/repo") to ignore from PR agent processing
+ignore_repositories = [] # a list of regular expressions of repository full names (e.g. "org/repo") to ignore from PR agent processing
 #
 is_auto_command = false # will be auto-set to true if the command is triggered by an automation
 enable_ai_metadata = false # will enable adding ai metadata

--- a/tests/unittest/test_ignore_repositories.py
+++ b/tests/unittest/test_ignore_repositories.py
@@ -51,7 +51,7 @@ class TestIgnoreRepositories:
             "sender": {"login": "user"}
         }
         result = provider_func(body_func(body["repository"]["full_name"]))
-        print(f"DEBUG: Provider={provider_name}, test_should_ignore_matching_repository, result={result}")
+        # print(f"DEBUG: Provider={provider_name}, test_should_ignore_matching_repository, result={result}")
         assert result is False, f"{provider_name}: PR from ignored repository should be ignored (return False)"
 
     @pytest.mark.parametrize("provider_name, provider_func, body_func", PROVIDERS)
@@ -63,7 +63,7 @@ class TestIgnoreRepositories:
             "sender": {"login": "user"}
         }
         result = provider_func(body_func(body["repository"]["full_name"]))
-        print(f"DEBUG: Provider={provider_name}, test_should_not_ignore_non_matching_repository, result={result}")
+        # print(f"DEBUG: Provider={provider_name}, test_should_not_ignore_non_matching_repository, result={result}")
         assert result is True, f"{provider_name}: PR from non-ignored repository should not be ignored (return True)"
 
     @pytest.mark.parametrize("provider_name, provider_func, body_func", PROVIDERS)
@@ -75,5 +75,5 @@ class TestIgnoreRepositories:
             "sender": {"login": "user"}
         }
         result = provider_func(body_func(body["repository"]["full_name"]))
-        print(f"DEBUG: Provider={provider_name}, test_should_not_ignore_when_config_empty, result={result}")
+        # print(f"DEBUG: Provider={provider_name}, test_should_not_ignore_when_config_empty, result={result}")
         assert result is True, f"{provider_name}: PR should not be ignored if ignore_repositories config is empty" 

--- a/tests/unittest/test_ignore_repositories.py
+++ b/tests/unittest/test_ignore_repositories.py
@@ -1,0 +1,79 @@
+import pytest
+from pr_agent.servers.github_app import should_process_pr_logic as github_should_process_pr_logic
+from pr_agent.servers.bitbucket_app import should_process_pr_logic as bitbucket_should_process_pr_logic
+from pr_agent.servers.gitlab_webhook import should_process_pr_logic as gitlab_should_process_pr_logic
+from pr_agent.config_loader import get_settings
+
+def make_bitbucket_payload(full_name):
+    return {
+        "data": {
+            "pullrequest": {
+                "title": "Test PR",
+                "source": {"branch": {"name": "feature/test"}},
+                "destination": {
+                    "branch": {"name": "main"},
+                    "repository": {"full_name": full_name}
+                }
+            },
+            "actor": {"username": "user", "type": "user"}
+        }
+    }
+
+def make_github_body(full_name):
+    return {
+        "pull_request": {},
+        "repository": {"full_name": full_name},
+        "sender": {"login": "user"}
+    }
+
+def make_gitlab_body(full_name):
+    return {
+        "object_attributes": {"title": "Test MR"},
+        "project": {"path_with_namespace": full_name}
+    }
+
+PROVIDERS = [
+    ("github", github_should_process_pr_logic, make_github_body),
+    ("bitbucket", bitbucket_should_process_pr_logic, make_bitbucket_payload),
+    ("gitlab", gitlab_should_process_pr_logic, make_gitlab_body),
+]
+
+class TestIgnoreRepositories:
+    def setup_method(self):
+        get_settings().set("CONFIG.IGNORE_REPOSITORIES", [])
+
+    @pytest.mark.parametrize("provider_name, provider_func, body_func", PROVIDERS)
+    def test_should_ignore_matching_repository(self, provider_name, provider_func, body_func):
+        get_settings().set("CONFIG.IGNORE_REPOSITORIES", ["org/repo-to-ignore"])
+        body = {
+            "pull_request": {},
+            "repository": {"full_name": "org/repo-to-ignore"},
+            "sender": {"login": "user"}
+        }
+        result = provider_func(body_func(body["repository"]["full_name"]))
+        print(f"DEBUG: Provider={provider_name}, test_should_ignore_matching_repository, result={result}")
+        assert result is False, f"{provider_name}: PR from ignored repository should be ignored (return False)"
+
+    @pytest.mark.parametrize("provider_name, provider_func, body_func", PROVIDERS)
+    def test_should_not_ignore_non_matching_repository(self, provider_name, provider_func, body_func):
+        get_settings().set("CONFIG.IGNORE_REPOSITORIES", ["org/repo-to-ignore"])
+        body = {
+            "pull_request": {},
+            "repository": {"full_name": "org/other-repo"},
+            "sender": {"login": "user"}
+        }
+        result = provider_func(body_func(body["repository"]["full_name"]))
+        print(f"DEBUG: Provider={provider_name}, test_should_not_ignore_non_matching_repository, result={result}")
+        assert result is True, f"{provider_name}: PR from non-ignored repository should not be ignored (return True)"
+
+    @pytest.mark.parametrize("provider_name, provider_func, body_func", PROVIDERS)
+    def test_should_not_ignore_when_config_empty(self, provider_name, provider_func, body_func):
+        get_settings().set("CONFIG.IGNORE_REPOSITORIES", [])
+        body = {
+            "pull_request": {},
+            "repository": {"full_name": "org/repo-to-ignore"},
+            "sender": {"login": "user"}
+        }
+        result = provider_func(body_func(body["repository"]["full_name"]))
+        print(f"DEBUG: Provider={provider_name}, test_should_not_ignore_when_config_empty, result={result}")
+        assert result is True, f"{provider_name}: PR should not be ignored if ignore_repositories config is empty" 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Added `ignore_repositories` config to filter PRs/MRs by repository.
  - Implemented in GitHub, Bitbucket, and GitLab webhook logic.
  - Supports regex pattern matching for flexible filtering.

- Updated documentation to explain new repository ignore feature.

- Added comprehensive unit tests for repository ignore logic.

- Extended example configuration to include `ignore_repositories`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github_app.py</strong><dd><code>Add repository ignore logic to GitHub webhook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/github_app.py

<li>Added logic to ignore PRs from repositories matching <br><code>ignore_repositories</code>.<br> <li> Integrated regex matching for repository names.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1786/files#diff-3fb3f174152732d1b69953c8bd81b8a0a30f0e42100dc626d932da8371851608">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bitbucket_app.py</strong><dd><code>Add repository ignore logic to Bitbucket webhook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/bitbucket_app.py

<li>Added repository ignore logic using <code>ignore_repositories</code> config.<br> <li> Used regex matching for repository full names.<br> <li> Added debug print for logic tracing.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1786/files#diff-963a9de391ff22ad3083c3a28c1d5736d68a6e1e40b0bedb52d4bfd124325bad">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gitlab_webhook.py</strong><dd><code>Add repository ignore logic to GitLab webhook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/gitlab_webhook.py

<li>Implemented repository ignore logic using <code>ignore_repositories</code>.<br> <li> Used regex matching for repository path.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1786/files#diff-c3ea1ba460930c6e6e6a2c36a7dc729d79730a96e872d40ffb246f80bc7c0880">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Add ignore_repositories to configuration example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml

- Added `ignore_repositories` config option with documentation.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1786/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>additional_configurations.md</strong><dd><code>Document repository ignore configuration and usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/usage-guide/additional_configurations.md

<li>Documented new <code>ignore_repositories</code> feature with usage example.<br> <li> Updated configuration code blocks and explanations.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1786/files#diff-9290a3ad9a86690b31f0450b77acd37ef1914b41fabc8a08682d4da433a77f90">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ignore_repositories.py</strong><dd><code>Add tests for ignore_repositories filtering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_ignore_repositories.py

<li>Added unit tests for repository ignore logic across all providers.<br> <li> Tested matching, non-matching, and empty config scenarios.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1786/files#diff-c101037e76d8d880e1b557c3815cd72de78f22847023bc896fdcd5c2110d2300">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>