### PR TITLE
docs: document how to auto-trigger /add_docs via pr_commands

### DIFF
--- a/docs/docs/tools/documentation.md
+++ b/docs/docs/tools/documentation.md
@@ -26,6 +26,25 @@ You can state a name of a specific component in the PR to get documentation only
 /add_docs component_name
 ```
 
+## Automatic triggering
+
+To automatically run the `add_docs` tool when a pull request is opened, configure your `.pr_agent.yaml` or `configuration.toml` as follows:
+
+```toml
+[github_app]
+pr_commands = [
+    "/describe",
+    "/review",
+    "/improve",
+    "/add_docs"
+]
+```
+
+!!! note
+    This behavior is **opt-in**; by default `/add_docs` only runs on manual invocation.
+
+
+
 ## Configuration options
 
 - `docs_style`: The exact style of the documentation (for python docstring). you can choose between: `google`, `numpy`, `sphinx`, `restructuredtext`, `plain`. Default is `sphinx`.

--- a/docs/docs/tools/documentation.md
+++ b/docs/docs/tools/documentation.md
@@ -43,8 +43,6 @@ pr_commands = [
 !!! note
     This behavior is **opt-in**; by default `/add_docs` only runs on manual invocation.
 
-
-
 ## Configuration options
 
 - `docs_style`: The exact style of the documentation (for python docstring). you can choose between: `google`, `numpy`, `sphinx`, `restructuredtext`, `plain`. Default is `sphinx`.


### PR DESCRIPTION
## Related Issue

[#1768](https://github.com/Codium-ai/pr-agent/issues/1768) - Support auto‐run of add_docs on PR open

## Summary

This PR updates the official documentation for the `/add_docs` tool by introducing a new section: **Automatic triggering**.  
The section explains how to configure the tool to run automatically on PR open, by adding it to the `pr_commands` list in `.pr_agent.yaml` or `configuration.toml`.

## Background

In #1768, it was clarified that `/add_docs` is not enabled by default for automatic execution.  
However, users can opt into this behavior by including the command in their configuration, as is done with `/describe`, `/review`, and `/improve`.

Currently, this setup detail was **not documented anywhere**, which could lead to confusion for teams attempting to activate the tool.

## What’s included

- A new subsection under `docs/docs/tools/documentation.md` named **"Automatic triggering"**
- Usage example showing how to include `/add_docs` in `pr_commands`
- An explicit note that this setup is **opt-in**, and not active by default

## Motivation

This contribution aims to:
- Help users discover that `/add_docs` can be triggered automatically through configuration
- Align its documentation with other tools like `/describe` and `/review`, which already include such instructions
- Reduce the onboarding effort for teams wanting to adopt docstring generation in their workflows

---

This PR includes **documentation only**, and **does not introduce any code changes or behavioral modifications**.  
It addresses the maintainer’s suggestion [here](https://github.com/qodo-ai/pr-agent/pull/1794#issuecomment-2889614957).

I’d greatly appreciate your review and feedback.  
Please let me know if any adjustments are needed.

Thank you for your continued guidance!
