### PR TITLE
Adding num_max_findings configuration parameter

### DIFF
--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -70,6 +70,10 @@ extra_instructions = "..."
         <td><b>enable_help_text</b></td>
         <td>If set to true, the tool will display a help text in the comment. Default is true.</td>
       </tr>
+      <tr>
+        <td><b>num_max_findings</b></td>
+        <td>Number of maximum returned finding. Default is 3.</td>
+      </tr>
     </table>
 
 !!! example "Enable\\disable specific sub-sections"

--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -72,7 +72,7 @@ extra_instructions = "..."
       </tr>
       <tr>
         <td><b>num_max_findings</b></td>
-        <td>Number of maximum returned finding. Default is 3.</td>
+        <td>Number of maximum returned findings. Default is 3.</td>
       </tr>
     </table>
 

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -81,6 +81,7 @@ require_ticket_analysis_review=true
 # general options
 persistent_comment=true
 extra_instructions = ""
+num_max_findings = 3
 final_update_message = true
 # review labels
 enable_review_labels_security=true

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -98,7 +98,7 @@ class Review(BaseModel):
 {%- if question_str %}
     insights_from_user_answers: str = Field(description="shortly summarize the insights you gained from the user's answers to the questions")
 {%- endif %}
-    key_issues_to_review: List[KeyIssuesComponentLink] = Field("A short and diverse list (0-3 issues) of high-priority bugs, problems or performance concerns introduced in the PR code, which the PR reviewer should further focus on and validate during the review process.")
+    key_issues_to_review: List[KeyIssuesComponentLink] = Field("A short and diverse list (0-{{ num_max_findings }} issues) of high-priority bugs, problems or performance concerns introduced in the PR code, which the PR reviewer should further focus on and validate during the review process.")
 {%- if require_security_review %}
     security_concerns: str = Field(description="Does this PR code introduce possible vulnerabilities such as exposure of sensitive information (e.g., API keys, secrets, passwords), or security concerns like SQL injection, XSS, CSRF, and others ? Answer 'No' (without explaining why) if there are no possible issues. If there are security concerns or issues, start your answer with a short header, such as: 'Sensitive information exposure: ...', 'SQL injection: ...' etc. Explain your answer. Be specific and give examples if possible")
 {%- endif %}

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -81,6 +81,7 @@ class PRReviewer:
             "language": self.main_language,
             "diff": "",  # empty diff for initial calculation
             "num_pr_files": self.git_provider.get_num_of_files(),
+            "num_max_findings": get_settings().pr_reviewer.num_max_findings,
             "require_score": get_settings().pr_reviewer.require_score_review,
             "require_tests": get_settings().pr_reviewer.require_tests_review,
             "require_estimate_effort_to_review": get_settings().pr_reviewer.require_estimate_effort_to_review,


### PR DESCRIPTION
### **User description**
Adding num_max_findings configuration parameter with a default value of 3, to have the possibility to extend it


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduced `num_max_findings` configuration for PR reviewer.
  - Added default value and usage in code.
  - Updated documentation to describe the new parameter.
  - Incorporated parameter into reviewer prompt templates.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer.py</strong><dd><code>Inject `num_max_findings` into reviewer context variables</code></dd></summary>
<hr>

pr_agent/tools/pr_reviewer.py

<li>Added <code>num_max_findings</code> to reviewer variables from settings.<br> <li> Enables dynamic control of maximum findings in reviews.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1797/files#diff-8e265068e189a06852605cc694b03e92b523b4f8162077a2f3455ced4cdad8dc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Add `num_max_findings` default to reviewer configuration</code>&nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml

<li>Added <code>num_max_findings = 3</code> to reviewer configuration.<br> <li> Sets default maximum findings for PR reviews.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1797/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer_prompts.toml</strong><dd><code>Use `num_max_findings` in reviewer prompt template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/pr_reviewer_prompts.toml

<li>Updated prompt to use <code>num_max_findings</code> for key issues list.<br> <li> Makes findings count dynamically reflect configuration.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1797/files#diff-2e1ca45d2d8635b5f9cde801d9d210f6516e7f15d45dd9b0be134ac91e7a2e63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>review.md</strong><dd><code>Document `num_max_findings` parameter in review tool docs</code></dd></summary>
<hr>

docs/docs/tools/review.md

<li>Documented new <code>num_max_findings</code> configuration parameter.<br> <li> Explained its purpose and default value.


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1797/files#diff-8e6363749b8b0a82468e5fbb0796cee806dc48e70e7472b04088d56d2c415094">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>