### PR TITLE
Revise the review effort label text in the review document

### DIFF
--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -112,7 +112,7 @@ extra_instructions = "..."
       </tr>
       <tr>
         <td><b>enable_review_labels_effort</b></td>
-        <td>If set to true, the tool will publish a 'Review effort [1-5]: x' label. Default is true.</td>
+        <td>If set to true, the tool will publish a 'Review effort x/5' label (1–5 scale). Default is true.</td>
       </tr>
     </table>
 
@@ -141,7 +141,7 @@ extra_instructions = "..."
     The `review` tool can auto-generate two specific types of labels for a PR:
 
     - a `possible security issue` label that detects if a possible [security issue](https://github.com/Codium-ai/pr-agent/blob/tr/user_description/pr_agent/settings/pr_reviewer_prompts.toml#L136) exists in the PR code (`enable_review_labels_security` flag)
-    - a `Review effort [1-5]: x` label, where x is the estimated effort to review the PR (`enable_review_labels_effort` flag)
+    - a `Review effort x/5` label, where x is the estimated effort to review the PR on a 1–5 scale (`enable_review_labels_effort` flag)
 
     Both modes are useful, and we recommended to enable them.
 


### PR DESCRIPTION
### **User description**
- Revise the review effort label text in the review document to an updated format


___

### **PR Type**
Documentation


___

### **Description**
- Update review effort label text to new format

- Clarify label description in configuration table and usage section


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>review.md</strong><dd><code>Revise review effort label format and description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/tools/review.md

<li>Changed review effort label description from 'Review effort [1-5]: x' <br>to 'Review effort x/5'<br> <li> Updated both configuration table and label usage explanation


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1799/files#diff-8e6363749b8b0a82468e5fbb0796cee806dc48e70e7472b04088d56d2c415094">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>