### PR TITLE
fix: reorder exception handling in `LiteLLMAIHandler.chat_completion()`

### DIFF
--- a/pr_agent/algo/ai_handlers/litellm_ai_handler.py
+++ b/pr_agent/algo/ai_handlers/litellm_ai_handler.py
@@ -371,11 +371,11 @@ class LiteLLMAIHandler(BaseAiHandler):
                 get_logger().info(f"\nUser prompt:\n{user}")
 
             response = await acompletion(**kwargs)
-        except (openai.APIError, openai.APITimeoutError) as e:
-            get_logger().warning(f"Error during LLM inference: {e}")
-            raise
         except (openai.RateLimitError) as e:
             get_logger().error(f"Rate limit error during LLM inference: {e}")
+            raise
+        except (openai.APIError, openai.APITimeoutError) as e:
+            get_logger().warning(f"Error during LLM inference: {e}")
             raise
         except (Exception) as e:
             get_logger().warning(f"Unknown error during LLM inference: {e}")


### PR DESCRIPTION
### **User description**
## Description
This PR fixes the exception handling order in `LiteLLMAIHandler.chat_completion()` to properly catch `RateLimitError` before its parent class `APIError`.

### Changes
- Reordered exception blocks to catch more specific exceptions (`RateLimitError`) first
- Preserves the retry behavior design where `RateLimitError` should not trigger retries

closes #1802


___

### **PR Type**
Bug fix


___

### **Description**
- Reordered exception handling in `LiteLLMAIHandler.chat_completion`
  - Now catches `RateLimitError` before `APIError`
  - Ensures retry logic does not trigger on rate limits

- Corrected logging level for rate limit errors


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>litellm_ai_handler.py</strong><dd><code>Reorder exception handling to fix retry behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/ai_handlers/litellm_ai_handler.py

<li>Moved <code>RateLimitError</code> except block before <code>APIError</code> block<br> <li> Ensures <code>RateLimitError</code> is not retried and is logged as error<br> <li> Maintains intended retry behavior for other API errors


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1803/files#diff-ea1acaa0907f3410665530fbc4cda2ab524de2772e0bbe10bad4648b8be35dfe">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>