### PR TITLE
Feature/test get max tokens

### DIFF
--- a/tests/unittest/test_get_max_tokens.py
+++ b/tests/unittest/test_get_max_tokens.py
@@ -1,0 +1,67 @@
+import pytest
+from pr_agent.algo.utils import get_max_tokens, MAX_TOKENS
+import pr_agent.algo.utils as utils
+
+class TestGetMaxTokens:
+
+    # Test if the file is in MAX_TOKENS
+    def test_model_max_tokens(self, monkeypatch):
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 0,
+                'max_model_tokens': 0
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        model = "gpt-3.5-turbo"
+        expected = MAX_TOKENS[model]
+
+        assert get_max_tokens(model) == expected
+
+    # Test situations where the model is not registered and exists as a custom model
+    def test_model_has_custom(self, monkeypatch):
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 5000,
+                'max_model_tokens': 0  # 제한 없음
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        model = "custom-model"
+        expected = 5000
+
+        assert get_max_tokens(model) == expected
+
+    def test_model_not_max_tokens_and_not_has_custom(self, monkeypatch):
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 0,
+                'max_model_tokens': 0
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        model = "custom-model"
+
+        with pytest.raises(Exception):
+            get_max_tokens(model)
+
+    def test_model_max_tokens_with__limit(self, monkeypatch):
+        fake_settings = type('', (), {
+            'config': type('', (), {
+                'custom_model_max_tokens': 0,
+                'max_model_tokens': 10000
+            })()
+        })()
+
+        monkeypatch.setattr(utils, "get_settings", lambda: fake_settings)
+
+        model = "gpt-3.5-turbo"  # this model setting is 160000
+        expected = 10000
+
+        assert get_max_tokens(model) == expected

--- a/tests/unittest/test_language_handler.py
+++ b/tests/unittest/test_language_handler.py
@@ -79,13 +79,14 @@ class TestSortFilesByMainLanguages:
         files = [
             type('', (object,), {'filename': 'file1.py'})(),
             type('', (object,), {'filename': 'file2.java'})(),
-            type('', (object,), {'filename': 'file3.cpp'})()
+            type('', (object,), {'filename': 'file3.cpp'})(),
+            type('', (object,), {'filename': 'file3.test'})()
         ]
         expected_output = [
             {'language': 'Python', 'files': [files[0]]},
             {'language': 'Java', 'files': [files[1]]},
             {'language': 'C++', 'files': [files[2]]},
-            {'language': 'Other', 'files': []}
+            {'language': 'Other', 'files': [files[3]]}
         ]
         assert sort_files_by_main_languages(languages, files) == expected_output
 


### PR DESCRIPTION
- What this PR does
This PR adds a dedicated unit test file for the get_max_tokens() utility function in tests/unittest/test_get_max_tokens.py.

It ensures correct behavior under various configuration conditions and improves overall test coverage for the token handling logic.

- Why this is needed
The get_max_tokens() function includes conditional logic based on whether:

the model is predefined in MAX_TOKENS,

a custom token limit is set (custom_model_max_tokens),

or a global max limit (max_model_tokens) is applied.

These conditions are crucial for safe model usage and avoiding token overflows. However, they were not previously covered by unit tests.

This PR introduces precise tests for each branch of this logic.

- Summary of test cases added
✅ test_model_max_tokens:
Verifies token value from predefined MAX_TOKENS.

✅ test_model_has_custom:
Checks handling when the model is not in MAX_TOKENS, but custom_model_max_tokens is set.

✅ test_model_not_max_tokens_and_not_has_custom:
Ensures exception is raised when neither predefined tokens nor custom tokens exist.

✅ test_model_max_tokens_with__limit:
Verifies that the global cap max_model_tokens overrides model's default if it is set.