### PR TITLE
fix: avoid rare cases where the AI reviewer merely describes the changes

### DIFF
--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -1,6 +1,6 @@
 [pr_review_prompt]
 system="""You are PR-Reviewer, a language model designed to review a Git Pull Request (PR).
-Your task is to provide constructive and concise feedback for the PR.
+Your task is to provide constructive and concise feedback for the PR. Focus on identifying potential issues, areas for improvement, and bugs rather than merely describing changes.
 The review should focus on new code added in the PR code diff (lines starting with '+')
 
 

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -98,7 +98,7 @@ class Review(BaseModel):
 {%- if question_str %}
     insights_from_user_answers: str = Field(description="shortly summarize the insights you gained from the user's answers to the questions")
 {%- endif %}
-    key_issues_to_review: List[KeyIssuesComponentLink] = Field("A short and diverse list (0-{{ num_max_findings }} issues) of high-priority bugs, problems or performance concerns introduced in the PR code, which the PR reviewer should further focus on and validate during the review process.")
+    key_issues_to_review: List[KeyIssuesComponentLink] = Field("A short and diverse list (0-{{ num_max_findings }} issues) of high-priority bugs, potential problems, performance concerns, or areas for improvement introduced or affected by the new code in the PR. This list should guide the reviewer to specific areas requiring validation or deeper inspection, and never merely describe the changes made.")
 {%- if require_security_review %}
     security_concerns: str = Field(description="Does this PR code introduce possible vulnerabilities such as exposure of sensitive information (e.g., API keys, secrets, passwords), or security concerns like SQL injection, XSS, CSRF, and others ? Answer 'No' (without explaining why) if there are no possible issues. If there are security concerns or issues, start your answer with a short header, such as: 'Sensitive information exposure: ...', 'SQL injection: ...' etc. Explain your answer. Be specific and give examples if possible")
 {%- endif %}

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -87,7 +87,7 @@ class Review(BaseModel):
     ticket_compliance_check: List[TicketCompliance] = Field(description="A list of compliance checks for the related tickets")
 {%- endif %}
 {%- if require_estimate_effort_to_review %}
-    estimated_effort_to_review_[1-5]: int = Field(description="Estimate, on a scale of 1-5 (inclusive), the time and effort required to review this PR by an experienced and knowledgeable developer. 1 means short and easy review , 5 means long and hard review. Take into account the size, complexity, quality, and the needed changes of the PR code diff.")
+    estimated_effort_to_review_[1-5]: int = Field(description="Estimate, on a scale of 1-5 (inclusive), the time and effort required to review this PR by an experienced and knowledgeable developer. 1 means short and easy review, 5 means long and hard review. Take into account the size, complexity, quality, and the needed changes of the PR code diff.")
 {%- endif %}
 {%- if require_score %}
     score: str = Field(description="Rate this PR on a scale of 0-100 (inclusive), where 0 means the worst possible PR code, and 100 means PR code of the highest quality, without any bugs or performance issues, that is ready to be merged immediately and run in production at scale.")

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -1,6 +1,6 @@
 [pr_review_prompt]
 system="""You are PR-Reviewer, a language model designed to review a Git Pull Request (PR).
-Your task is to provide constructive and concise feedback for the PR. Focus on identifying potential issues, areas for improvement, and bugs rather than merely describing changes.
+Your task is to provide constructive and concise feedback for the PR.
 The review should focus on new code added in the PR code diff (lines starting with '+')
 
 


### PR DESCRIPTION
### **User description**
## Problem Example

Here's an invalid AI comment that offers no remarks or suggestions and merely repeats the evident, known fact about what was changed: https://github.com/qodo-ai/pr-agent/pull/1745#issuecomment-2858073685

---

## Why?

Describing the changes belongs in the pull request description and commit messages. A reviewer's purpose is to point out bugs and errors and to suggest improvements.


___

### **PR Type**
Enhancement


___

### **Description**
• Updated PR reviewer prompt to focus on identifying issues and improvements
• Added guidance to avoid merely describing changes in reviews


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Original Prompt"] -- "Enhanced with guidance" --> B["Updated Prompt"]
  B --> C["Focus on Issues & Improvements"]
  B --> D["Avoid Describing Changes"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer_prompts.toml</strong><dd><code>Enhanced reviewer prompt for better feedback focus</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/pr_reviewer_prompts.toml

• Enhanced system prompt with explicit guidance to focus on <br>identifying issues and improvements<br> • Added instruction to avoid <br>merely describing changes in PR reviews


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1863/files#diff-2e1ca45d2d8635b5f9cde801d9d210f6516e7f15d45dd9b0be134ac91e7a2e63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>