### PR TITLE
feat: support self-signed gitea cert

### DIFF
--- a/docs/docs/installation/gitea.md
+++ b/docs/docs/installation/gitea.md
@@ -39,6 +39,8 @@ GITEA__PERSONAL_ACCESS_TOKEN=<personal_access_token>
 GITEA__WEBHOOK_SECRET=<webhook_secret>
 GITEA__URL=https://gitea.com # Or self host
 OPENAI__KEY=<your_openai_api_key>
+GITEA__SKIP_SSL_VERIFICATION=false # or true
+GITEA__SSL_CA_CERT=/path/to/cacert.pem
 ```
 
 8. Create a webhook in your Gitea project. Set the URL to `http[s]://<PR_AGENT_HOSTNAME>/api/v1/gitea_webhooks`, the secret token to the generated secret from step 3, and enable the triggers `push`, `comments` and `merge request events`.

--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -41,6 +41,12 @@ class GiteaProvider(GitProvider):
         configuration.host = "{}/api/v1".format(self.base_url)
         configuration.api_key['Authorization'] = f'token {gitea_access_token}'
 
+        if get_settings().get("GITEA.SKIP_SSL_VERIFICATION", False):
+            configuration.verify_ssl = False
+
+        # Use custom cert (self-signed)
+        configuration.ssl_ca_cert = get_settings().get("GITEA.SSL_CA_CERT", None)
+
         client = giteapy.ApiClient(configuration)
         self.repo_api = RepoApi(client)
         self.owner = None


### PR DESCRIPTION
### **User description**
Hi ! :wave: 

Thanks for this project, it's awesome ! 
I'm currently testing it with a self-hosted Gitea instance, but I can't trust my self-signed certificate. 

This PR add two optional configuration settings on `GITEA` topics.
 - `GITEA.SKIP_SSL_VERIFICATION` (bool) that disable SSL verification on gitea client
 - `GITEA.SSL_CA_CERT` (string) to customise the path of trusted store.

Do you want a documentation for non-mandatory argument ? 
I guess it will be in `docs/docs/installation/gitea.md` ?

My testing setup : 

<details>
 <summary>docker-compose.yml</summary>

```yaml

services:
  gitea-1.24: 
    image: gitea/gitea:1.24.0
    environment:
      GITEA__server__PROTOCOL: https
      GITEA__server__ROOT_URL: https://localhost:3000
      GITEA__server__CERT_FILE: /cert.pem
      GITEA__server__KEY_FILE: /key.pem
    ports:
      - 3000:3000
    volumes:
      - ./cert.pem:/cert.pem:ro
      - ./key.pem:/key.pem:ro
```
</details>

<details>
<summary>Instructions</summary>

```bash


source venv/bin/activate
pip install -r requirements.txt
pip install -r requirements-dev.txt

openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=localhost" -addext "subjectAltName = DNS:localhost"

docker compose up -d

# Generate a token 
# Create a PR from a migration in https://localhost:3000/gitea/palbot/pulls/1

export PYTHONPATH=$(pwd)
export CONFIG__GIT_PROVIDER="gitea"

export GITEA__URL="https://localhost:3000"
export GITEA__PERSONAL_ACCESS_TOKEN="xxxx"

export GITEA__SKIP_SSL_VERIFICATION=false
export GITEA__SSL_CA_CERT="/home/nicolas/other/pr-agent/tmp/cert.pem"

python3 pr_agent/cli.py --pr_url="https://localhost:3000/gitea/palbot/pulls/1" review
```
</details>


___

### **PR Type**
Enhancement


___

### **Description**
• Add SSL verification skip option for Gitea
• Add custom SSL CA certificate path support
• Enable self-signed certificate compatibility


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Gitea Configuration"] --> B["SSL Verification Skip"]
  A --> C["Custom CA Certificate"]
  B --> D["Self-signed Cert Support"]
  C --> D
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitea_provider.py</strong><dd><code>Add SSL configuration for Gitea client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/gitea_provider.py

• Add <code>GITEA.SKIP_SSL_VERIFICATION</code> setting to disable SSL verification<br> <br>• Add <code>GITEA.SSL_CA_CERT</code> setting for custom CA certificate path<br> • <br>Configure SSL options in Gitea API client initialization


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1868/files#diff-72248e291297fdc9b50150b3a369f958d8ac3c8e2b8fe69e7a6f9d72810aebdc">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>