### PR TITLE
Add language-specific instructions to extra instructions based on user settings

### DIFF
--- a/pr_agent/git_providers/utils.py
+++ b/pr_agent/git_providers/utils.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 
 from dynaconf import Dynaconf
+from dynaconf.utils.boxing import DynaBox
 from starlette_context import context
 
 from pr_agent.config_loader import get_settings
@@ -61,6 +62,28 @@ def apply_repo_settings(pr_url):
     # enable switching models with a short definition
     if get_settings().config.model.lower() == 'claude-3-5-sonnet':
         set_claude_model()
+
+    # Append the response language in the extra instructions
+    response_language = get_settings().config.get('response_language', 'en-us')
+    if response_language.lower() != 'en-us':
+        get_logger().info(f'User has set the response language to: {response_language}')
+
+        lang_instruction_text = f"Your response MUST be written in the language corresponding to locale code: '{response_language}'. This is crucial."
+        separator_text = "\n======\n\nIn addition, "
+
+        for key in get_settings():
+            setting = get_settings().get(key)
+            if isinstance(setting, DynaBox):
+                if key.lower() in ['pr_description', 'pr_code_suggestions', 'pr_reviewer']:
+                    if hasattr(setting, 'extra_instructions'):
+                        extra_instructions = setting.extra_instructions
+
+                        if lang_instruction_text not in str(extra_instructions):
+                            updated_instructions = (
+                                str(extra_instructions) + separator_text + lang_instruction_text
+                                if extra_instructions else lang_instruction_text
+                            )
+                            setting.extra_instructions = updated_instructions
 
 
 def handle_configurations_errors(config_errors, git_provider):


### PR DESCRIPTION
## Background (Why)
Although we had configured the feature to merge language-specific instructions from user settings into the extra instructions, that logic was not being executed in our GitHub Action.

## Changes (What)
- Added logic to merge language-specific instructions specified in user settings into the `extra_instructions` array  