### PR TITLE
test: auto-trigger /add_docs on PR opened events

### DIFF
--- a/tests/unittest/test_add_docs_trigger.py
+++ b/tests/unittest/test_add_docs_trigger.py
@@ -1,0 +1,92 @@
+import pytest
+from pr_agent.servers.github_app import handle_new_pr_opened
+from pr_agent.tools.pr_add_docs import PRAddDocs
+from pr_agent.agent.pr_agent import PRAgent
+from pr_agent.config_loader import get_settings
+from pr_agent.identity_providers.identity_provider import Eligibility
+from pr_agent.identity_providers import get_identity_provider
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action,draft,state,should_run",
+    [
+        ("opened", False, "open", True),
+        ("edited", False, "open", False),
+        ("opened", True, "open", False),
+        ("opened", False, "closed", False),
+    ],
+)
+async def test_add_docs_trigger(monkeypatch, action, draft, state, should_run):
+    # Mock settings to enable the "/add_docs" auto-command on PR opened
+    settings = get_settings()
+    settings.github_app.pr_commands = ["/add_docs"]
+    settings.github_app.handle_pr_actions = ["opened"]
+
+    # Define a FakeGitProvider for both apply_repo_settings and PRAddDocs
+    class FakeGitProvider:
+        def __init__(self, pr_url, *args, **kwargs):
+            self.pr = type("pr", (), {"title": "Test PR"})()
+            self.get_pr_branch = lambda: "test-branch"
+            self.get_pr_description = lambda: "desc"
+            self.get_languages = lambda: ["Python"]
+            self.get_files = lambda: []
+            self.get_commit_messages = lambda: "msg"
+            self.publish_comment = lambda *args, **kwargs: None
+            self.remove_initial_comment = lambda: None
+            self.publish_code_suggestions = lambda suggestions: True
+            self.diff_files = []
+            self.get_repo_settings = lambda: {}
+
+    # Patch Git provider lookups
+    monkeypatch.setattr(
+        "pr_agent.git_providers.utils.get_git_provider_with_context",
+        lambda pr_url: FakeGitProvider(pr_url),
+    )
+    monkeypatch.setattr(
+        "pr_agent.tools.pr_add_docs.get_git_provider",
+        lambda: FakeGitProvider,
+    )
+
+    # Ensure identity provider always eligible
+    monkeypatch.setattr(
+        get_identity_provider().__class__,
+        "verify_eligibility",
+        lambda *args, **kwargs: Eligibility.ELIGIBLE,
+    )
+
+    # Spy on PRAddDocs.run()
+    ran = {"flag": False}
+
+    async def fake_run(self):
+        ran["flag"] = True
+
+    monkeypatch.setattr(PRAddDocs, "run", fake_run)
+
+    # Build minimal PR payload
+    body = {
+        "action": action,
+        "pull_request": {
+            "url": "https://example.com/fake/pr",
+            "state": state,
+            "draft": draft,
+        },
+    }
+    log_context = {}
+
+    # Invoke the PR-open handler
+    agent = PRAgent()
+    await handle_new_pr_opened(
+        body=body,
+        event="pull_request",
+        sender="tester",
+        sender_id="123",
+        action=action,
+        log_context=log_context,
+        agent=agent,
+    )
+
+    assert ran["flag"] is should_run, (
+        f"Expected run() to be {'called' if should_run else 'skipped'}"
+        f" for action={action!r}, draft={draft}, state={state!r}"
+    )


### PR DESCRIPTION
### **User description**
###  Title
`/add_docs` auto-trigger: add positive & negative-case unit tests

---

### Background
`/add_docs` can run automatically on PR-*opened* events, but this code path is **currently untested**.  
Lack of coverage makes it hard to detect future regressions (e.g., firing on the wrong action or on draft PRs).

---

###  Objective (Acceptance Criteria)
* **Given** a non-draft, open PR and `action == "opened"`  
  **When** web-hook is handled  
  **Then** `PRAddDocs.run()` is called exactly once.
* **Given** any draft / closed PR **OR** any action ≠ `"opened"`  
  **Then** `PRAddDocs.run()` is *not* called.

---

###  Coverage Plan
- Parametrised test for 4 key cases (opened/edited × open/closed × draft flag)  
- Stub GitProvider & IdentityProvider  
- Monkeypatch `PRAddDocs.run` and assert exact invocation  
- Target ≥ 100 % branch coverage of `github_app._perform_auto_commands_github` decision logic.

---

### Why only tests?
- The config flag/work-flow change proposed in #1768 was already accepted in earlier PR #1768(docs only).
- This PR purposely focusses only on adding missing unit tests to guard the existing behaviour.

---

###  Follow-up
(unchanged)

### What’s inside
* ✅ Adds parametrised unit-test `test_add_docs_trigger`
* ✅ Covers positive & negative auto-trigger cases for `/add_docs`

---

### 🔗 Related PR

Will be resolved via: [[PR #1768](https://github.com/qodo-ai/pr-agent/issues/1768)]


___

### **PR Type**
Tests


___

### **Description**
- Add comprehensive unit tests for auto-trigger `/add_docs` functionality

- Cover positive and negative cases for PR opened events

- Ensure proper behavior based on PR state and action type

- Validate auto-command execution logic with parametrized testing


___

### **Changes diagram**

```mermaid
flowchart LR
  A["PR Event"] --> B["Test Handler"]
  B --> C["Mock Git Provider"]
  B --> D["Mock Identity Provider"]
  B --> E["Spy on PRAddDocs.run()"]
  E --> F["Assert Expected Behavior"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_add_docs_trigger.py</strong><dd><code>Comprehensive auto-trigger tests for add_docs command</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_add_docs_trigger.py

<li>Add parametrized test covering 4 scenarios (opened/edited × <br>draft/non-draft)<br> <li> Mock Git provider and identity provider for isolated testing<br> <li> Spy on <code>PRAddDocs.run()</code> method to verify execution<br> <li> Assert correct auto-trigger behavior based on PR state and action


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1891/files#diff-bdd094541b2dd326b2b00dafb0571ede13360cc0fcd220e531303d3497ebbdce">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>