### PR TITLE
Make azure webserver call async and return 202 immediately instead of waiting for review process to finish

### DIFF
--- a/pr_agent/servers/azuredevops_server_webhook.py
+++ b/pr_agent/servers/azuredevops_server_webhook.py
@@ -2,6 +2,7 @@
 # The server listens for incoming webhooks from Azure DevOps Server and forwards them to the PR Agent.
 # ADO webhook documentation: https://learn.microsoft.com/en-us/azure/devops/service-hooks/services/webhooks?view=azure-devops
 
+import asyncio
 import json
 import os
 import re
@@ -121,7 +122,7 @@ async def handle_request_azure(data, log_context):
         pr_url = unquote(data["resource"]["_links"]["web"]["href"].replace("_apis/git/repositories", "_git"))
         log_context["event"] = data["eventType"]
         log_context["api_url"] = pr_url
-        await _perform_commands_azure("pr_commands", PRAgent(), pr_url, log_context)
+        asyncio.create_task(_perform_commands_azure("pr_commands", PRAgent(), pr_url, log_context))
         return JSONResponse(
             status_code=status.HTTP_202_ACCEPTED,
             content=jsonable_encoder({"message": "webhook triggered successfully"})


### PR DESCRIPTION
### **User description**
Currently on receiving a Pull Request Created webhook from ADO, the server performs the PR commands, then when all is finished it returns a 202 code. I believe this is not the expected behavior given the 202 code, that it should instead start the command process in another thread and return the 202 immediately.

If the server it behaving as expected, I propose an alternative change to make that functionality configurable:
```
        if (get_settings().get(f"azure_devops_server.async", False)):
            asyncio.create_task(_perform_commands_azure("pr_commands", PRAgent(), pr_url, log_context))
            return JSONResponse(
                status_code=status.HTTP_202_ACCEPTED,
                content=jsonable_encoder({"message": "webhook triggered successfully"})
            )
        else:
            await _perform_commands_azure("pr_commands", PRAgent(), pr_url, log_context)
            return JSONResponse(
                status_code=status.HTTP_200_OK,
                content=jsonable_encoder({"message": "webhook triggered successfully"})
            ) 
```
This is particularly useful to have as an option as the pr commands may take a while to execute, which from the webhook side looks like a timeout failure, even when the review did process correctly. ADO automatically disables webhooks after repeated failures, so the ability to make sure that doesn't happen is crucial to keep the process functioning.


___

### **PR Type**
Enhancement


___

### **Description**
- Make Azure DevOps webhook handler truly asynchronous

- Return 202 status immediately without waiting for PR processing

- Prevent webhook timeouts and automatic disabling by ADO


___

### **Changes diagram**

```mermaid
flowchart LR
  webhook["Webhook Request"] --> task["Create Async Task"]
  task --> response["Return 202 Immediately"]
  task --> process["PR Processing in Background"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_server_webhook.py</strong><dd><code>Convert webhook handler to async task creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/azuredevops_server_webhook.py

<li>Replace <code>await</code> with <code>asyncio.create_task()</code> for PR command execution<br> <li> Return 202 status immediately instead of waiting for completion


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1900/files#diff-4525cb1c9c5ffe691dee1db5501c614ab50388fdf711220ee18db18cf64a7358">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>