### PR TITLE
fix: Remove trailing comma in gerrit provider prepare_repo function

### DIFF
--- a/pr_agent/git_providers/gerrit_provider.py
+++ b/pr_agent/git_providers/gerrit_provider.py
@@ -103,7 +103,7 @@ def prepare_repo(url: urllib3.util.Url, project, refspec):
     repo_url = (f"{url.scheme}://{url.auth}@{url.host}:{url.port}/{project}")
 
     directory = pathlib.Path(mkdtemp())
-    clone(repo_url, directory),
+    clone(repo_url, directory)
     fetch(repo_url, refspec, cwd=directory)
     checkout(cwd=directory)
     return directory


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove trailing comma causing syntax error in gerrit provider


___

### **Changes diagram**

```mermaid
flowchart LR
  A["gerrit_provider.py"] --> B["Remove trailing comma"] --> C["Fix syntax error"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gerrit_provider.py</strong><dd><code>Remove trailing comma syntax error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/gerrit_provider.py

<li>Remove trailing comma after <code>clone(repo_url, directory)</code> call<br> <li> Fix syntax error in <code>prepare_repo</code> function


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1922/files#diff-dae01da2d08399333945749d252be6d4f6b071e1add4e3079f58636b83c217d5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>