### PR TITLE
fix: clean up PR title formatting before publishing

### DIFF
--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -169,7 +169,8 @@ class PRDescription:
 
                 # publish description
                 if get_settings().pr_description.publish_description_as_comment:
-                    full_markdown_description = f"## Title\n\n{pr_title}\n\n___\n{pr_body}"
+                    pr_title_clean = pr_title.strip().replace('\n', ' ')
+                    full_markdown_description = f"## Title\n\n{pr_title_clean}\n\n___\n{pr_body}"
                     if get_settings().pr_description.publish_description_as_comment_persistent:
                         self.git_provider.publish_persistent_comment(full_markdown_description,
                                                                      initial_header="## Title",
@@ -179,7 +180,8 @@ class PRDescription:
                     else:
                         self.git_provider.publish_comment(full_markdown_description)
                 else:
-                    self.git_provider.publish_description(pr_title, pr_body)
+                    pr_title_clean = pr_title.strip().replace('\n', ' ')
+                    self.git_provider.publish_description(pr_title_clean, pr_body)
 
                     # publish final update message
                     if (get_settings().pr_description.final_update_message and not get_settings().config.get('is_auto_command', False)):

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -761,7 +761,9 @@ class PRDescription:
 
     @staticmethod
     def clean_title(title: str) -> str:
-        """Clean the PR title by normalizing all whitespace to a single space and stripping leading/trailing spaces."""
+        """Clean the PR title by normalizing all whitespace to a single space and stripping leading/trailing spaces. Returns empty string if input is None or empty."""
+        if not title:
+            return ""
         return re.sub(r'\s+', ' ', title.strip())
 
 

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -168,8 +168,8 @@ class PRDescription:
                         get_logger().debug(f"Labels are the same, not updating")
 
                 # publish description
+                pr_title_clean = pr_title.strip().replace('\n', ' ')
                 if get_settings().pr_description.publish_description_as_comment:
-                    pr_title_clean = pr_title.strip().replace('\n', ' ')
                     full_markdown_description = f"## Title\n\n{pr_title_clean}\n\n___\n{pr_body}"
                     if get_settings().pr_description.publish_description_as_comment_persistent:
                         self.git_provider.publish_persistent_comment(full_markdown_description,
@@ -180,7 +180,6 @@ class PRDescription:
                     else:
                         self.git_provider.publish_comment(full_markdown_description)
                 else:
-                    pr_title_clean = pr_title.strip().replace('\n', ' ')
                     self.git_provider.publish_description(pr_title_clean, pr_body)
 
                     # publish final update message

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -168,9 +168,8 @@ class PRDescription:
                         get_logger().debug(f"Labels are the same, not updating")
 
                 # publish description
-                pr_title_clean = self.clean_title(pr_title)
                 if get_settings().pr_description.publish_description_as_comment:
-                    full_markdown_description = f"## Title\n\n{pr_title_clean}\n\n___\n{pr_body}"
+                    full_markdown_description = f"## Title\n\n{pr_title.strip()}\n\n___\n{pr_body}"
                     if get_settings().pr_description.publish_description_as_comment_persistent:
                         self.git_provider.publish_persistent_comment(full_markdown_description,
                                                                      initial_header="## Title",
@@ -180,7 +179,7 @@ class PRDescription:
                     else:
                         self.git_provider.publish_comment(full_markdown_description)
                 else:
-                    self.git_provider.publish_description(pr_title_clean, pr_body)
+                    self.git_provider.publish_description(pr_title.strip(), pr_body)
 
                     # publish final update message
                     if (get_settings().pr_description.final_update_message and not get_settings().config.get('is_auto_command', False)):
@@ -759,12 +758,7 @@ class PRDescription:
 """
         return pr_body
 
-    @staticmethod
-    def clean_title(title: str) -> str:
-        """Clean the PR title by normalizing all whitespace to a single space and stripping leading/trailing spaces. Returns empty string if input is None or empty."""
-        if not title:
-            return ""
-        return re.sub(r'\s+', ' ', title.strip())
+
 
 
 def count_chars_without_html(string):

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -761,8 +761,8 @@ class PRDescription:
 
     @staticmethod
     def clean_title(title: str) -> str:
-        """Clean the PR title by stripping whitespace and replacing newlines with spaces."""
-        return title.strip().replace('\n', ' ')
+        """Clean the PR title by normalizing all whitespace to a single space and stripping leading/trailing spaces."""
+        return re.sub(r'\s+', ' ', title.strip())
 
 
 def count_chars_without_html(string):

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -758,9 +758,6 @@ class PRDescription:
 """
         return pr_body
 
-
-
-
 def count_chars_without_html(string):
     if '<' not in string:
         return len(string)

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -168,7 +168,7 @@ class PRDescription:
                         get_logger().debug(f"Labels are the same, not updating")
 
                 # publish description
-                pr_title_clean = pr_title.strip().replace('\n', ' ')
+                pr_title_clean = self.clean_title(pr_title)
                 if get_settings().pr_description.publish_description_as_comment:
                     full_markdown_description = f"## Title\n\n{pr_title_clean}\n\n___\n{pr_body}"
                     if get_settings().pr_description.publish_description_as_comment_persistent:
@@ -758,6 +758,12 @@ class PRDescription:
 </tr>
 """
         return pr_body
+
+    @staticmethod
+    def clean_title(title: str) -> str:
+        """Clean the PR title by stripping whitespace and replacing newlines with spaces."""
+        return title.strip().replace('\n', ' ')
+
 
 def count_chars_without_html(string):
     if '<' not in string:


### PR DESCRIPTION
### **User description**
fixes: #1930


___

### **PR Type**
Bug fix


___

### **Description**
- Clean up PR title formatting by removing newlines

- Replace newlines with spaces in generated titles

- Apply formatting to both comment and description publishing


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Generated PR Title"] --> B["Strip whitespace & replace newlines"]
  B --> C["Clean Title"]
  C --> D["Publish as Comment"]
  C --> E["Publish as Description"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description.py</strong><dd><code>Clean PR title formatting before publishing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_description.py

<li>Added <code>pr_title_clean</code> variable to strip whitespace and replace newlines <br>with spaces<br> <li> Applied title cleaning to both comment publishing and description <br>publishing paths<br> <li> Ensures clean formatting when titles are generated automatically


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1931/files#diff-66130451adce278a098a5770e2db52b12050205fcd4d80c13f813615d4449abb">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>