### PR TITLE
fix: add support for filtering ignored files in Bitbucket Server provider

### DIFF
--- a/pr_agent/algo/file_filter.py
+++ b/pr_agent/algo/file_filter.py
@@ -56,6 +56,8 @@ def filter_ignored(files, platform = 'github'):
                                 files_o.append(f)
                                 continue
                     files = files_o
+                elif platform == 'bitbucket_server':
+                    files = [f for f in files if not r.match(f['path']['toString'])]
                 elif platform == 'gitlab':
                     # files = [f for f in files if (f['new_path'] and not r.match(f['new_path']))]
                     files_o = []

--- a/pr_agent/git_providers/bitbucket_server_provider.py
+++ b/pr_agent/git_providers/bitbucket_server_provider.py
@@ -10,6 +10,7 @@ from requests.exceptions import HTTPError
 import shlex
 import subprocess
 
+from ..algo.file_filter import filter_ignored
 from ..algo.git_patch_processing import decode_if_bytes
 from ..algo.language_handler import is_valid_file
 from ..algo.types import EDIT_TYPE, FilePatchInfo
@@ -244,7 +245,8 @@ class BitbucketServerProvider(GitProvider):
         original_file_content_str = ""
         new_file_content_str = ""
 
-        changes = self.bitbucket_client.get_pull_requests_changes(self.workspace_slug, self.repo_slug, self.pr_num)
+        changes_original = list(self.bitbucket_client.get_pull_requests_changes(self.workspace_slug, self.repo_slug, self.pr_num))
+        changes = filter_ignored(changes_original, 'bitbucket_server')
         for change in changes:
             file_path = change['path']['toString']
             if not is_valid_file(file_path.split("/")[-1]):


### PR DESCRIPTION
The Bitbucket Server provider was missing the implementation to filter out ignored files during diff processing, while other Git providers  already had this feature working correctly.
This Pull Request enhances the provider to respect that config.