### PR TITLE
Fix: defer file sorting until after token calculation

### DIFF
--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -398,11 +398,6 @@ def get_pr_multi_diffs(git_provider: GitProvider,
     # Sort files by main language
     pr_languages = sort_files_by_main_languages(git_provider.get_languages(), diff_files)
 
-    # Sort files within each language group by tokens in descending order
-    sorted_files = []
-    for lang in pr_languages:
-        sorted_files.extend(sorted(lang['files'], key=lambda x: x.tokens, reverse=True))
-
     # Get the maximum number of extra lines before and after the patch
     PATCH_EXTRA_LINES_BEFORE = get_settings().config.patch_extra_lines_before
     PATCH_EXTRA_LINES_AFTER = get_settings().config.patch_extra_lines_after
@@ -419,6 +414,11 @@ def get_pr_multi_diffs(git_provider: GitProvider,
     # if we are under the limit, return the full diff
     if total_tokens + OUTPUT_BUFFER_TOKENS_SOFT_THRESHOLD < get_max_tokens(model):
         return ["\n".join(patches_extended)] if patches_extended else []
+
+    # Sort files within each language group by tokens in descending order
+    sorted_files = []
+    for lang in pr_languages:
+        sorted_files.extend(sorted(lang['files'], key=lambda x: x.tokens, reverse=True))
 
     patches = []
     final_diff_list = []


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Move file sorting logic after token calculation

- Prevent premature sorting before tokens are computed

- Ensure accurate token-based file ordering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Get diff files"] --> B["Sort by language"]
  B --> C["Calculate tokens"]
  C --> D["Check token limit"]
  D --> E["Sort files by tokens"]
  E --> F["Generate patches"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_processing.py</strong><dd><code>Defer file sorting until after token calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/pr_processing.py

<ul><li>Moved file sorting logic from before token calculation to after<br> <li> Relocated sorting block to execute only when token limit is exceeded<br> <li> Preserved original sorting behavior but with correct timing</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1970/files#diff-c2d64de584ef3cb05c9007d72137f6c7ce04c9bc23ce1931760af3a568edb04e">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

