### PR TITLE
docs: fix typo in OpenAI model parameter name to search

### DIFF
--- a/docs/docs/usage-guide/changing_a_model.md
+++ b/docs/docs/usage-guide/changing_a_model.md
@@ -379,7 +379,7 @@ To bypass chat templates and temperature controls, set `config.custom_reasoning_
 
 ```toml
 [config]
-reasoning_efffort = "medium" # "low", "medium", "high"
+reasoning_effort = "medium" # "low", "medium", "high"
 ```
 
 With the OpenAI models that support reasoning effort (eg: o4-mini), you can specify its reasoning effort via `config` section. The default value is `medium`. You can change it to `high` or `low` based on your usage.


### PR DESCRIPTION
### **User description**
- Fix spelling error: `reasoning_efffort` -> `reasoning_effort`


___

### **PR Type**
Documentation


___

### **Description**
- Fix typo in OpenAI model parameter name


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>changing_a_model.md</strong><dd><code>Fix parameter name typo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/usage-guide/changing_a_model.md

<ul><li>Correct spelling error in parameter name from <code>reasoning_efffort</code> to <br><code>reasoning_effort</code></ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1988/files#diff-7904af6a8722d533e7de626761ae6c1d9554069ed02634c3b719d2e7f8b39f4d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

