### PR TITLE
fix gitea/forgejo auth

### DIFF
--- a/pr_agent/git_providers/gitea_provider.py
+++ b/pr_agent/git_providers/gitea_provider.py
@@ -747,16 +747,14 @@ class RepoApi(giteapy.RepositoryApi):
     def get_pull_request_diff(self, owner: str, repo: str, pr_number: int) -> str:
         """Get the diff content of a pull request using direct API call"""
         try:
-            token = self.api_client.configuration.api_key.get('Authorization', '').replace('token ', '')
             url = f'/repos/{owner}/{repo}/pulls/{pr_number}.diff'
-            if token:
-                url = f'{url}?token={token}'
-
+            
             response = self.api_client.call_api(
                 url,
                 'GET',
                 path_params={},
                 response_type=None,
+                auth_settings=["AuthorizationHeaderToken"],
                 _return_http_data_only=False,
                 _preload_content=False
             )
@@ -803,16 +801,14 @@ class RepoApi(giteapy.RepositoryApi):
     def get_change_file_pull_request(self, owner: str, repo: str, pr_number: int):
         """Get changed files in the pull request"""
         try:
-            token = self.api_client.configuration.api_key.get('Authorization', '').replace('token ', '')
             url = f'/repos/{owner}/{repo}/pulls/{pr_number}/files'
-            if token:
-                url = f'{url}?token={token}'
-
+            
             response = self.api_client.call_api(
                 url,
                 'GET',
                 path_params={},
                 response_type=None,
+                auth_settings=["AuthorizationHeaderToken"],
                 _return_http_data_only=False,
                 _preload_content=False
             )
@@ -838,16 +834,14 @@ class RepoApi(giteapy.RepositoryApi):
     def get_languages(self, owner: str, repo: str):
         """Get programming languages used in the repository"""
         try:
-            token = self.api_client.configuration.api_key.get('Authorization', '').replace('token ', '')
             url = f'/repos/{owner}/{repo}/languages'
-            if token:
-                url = f'{url}?token={token}'
-
+        
             response = self.api_client.call_api(
                 url,
                 'GET',
                 path_params={},
                 response_type=None,
+                auth_settings=["AuthorizationHeaderToken"],
                 _return_http_data_only=False,
                 _preload_content=False
             )
@@ -872,16 +866,14 @@ class RepoApi(giteapy.RepositoryApi):
         """Get raw file content from a specific commit"""
 
         try:
-            token = self.api_client.configuration.api_key.get('Authorization', '').replace('token ', '')
             url = f'/repos/{owner}/{repo}/raw/{filepath}'
-            if token:
-                url = f'{url}?token={token}&ref={commit_sha}'
-
+    
             response = self.api_client.call_api(
                 url,
                 'GET',
                 path_params={},
                 response_type=None,
+                auth_settings=["AuthorizationHeaderToken"],
                 _return_http_data_only=False,
                 _preload_content=False
             )
@@ -965,16 +957,14 @@ class RepoApi(giteapy.RepositoryApi):
     def get_pr_commits(self, owner: str, repo: str, pr_number: int):
         """Get all commits in a pull request"""
         try:
-            token = self.api_client.configuration.api_key.get('Authorization', '').replace('token ', '')
             url = f'/repos/{owner}/{repo}/pulls/{pr_number}/commits'
-            if token:
-                url = f'{url}?token={token}'
 
             response = self.api_client.call_api(
                 url,
                 'GET',
                 path_params={},
                 response_type=None,
+                auth_settings=["AuthorizationHeaderToken"],
                 _return_http_data_only=False,
                 _preload_content=False
             )


### PR DESCRIPTION
### **User description**
Forgejo version 12 has [removed support](https://codeberg.org/forgejo/forgejo/pulls/7924) for API authentication via tokens in the URL `?token=...`. This should fix the use of pr-agent with newer forgejo version.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace deprecated URL token authentication with header-based auth

- Update five API methods to use `AuthorizationHeaderToken` setting

- Remove manual token extraction and URL parameter construction

- Fix compatibility with Forgejo version 12+ authentication changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["URL Token Auth"] -- "deprecated in v12" --> B["Header Token Auth"]
  B --> C["API Methods Updated"]
  C --> D["Forgejo Compatibility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitea_provider.py</strong><dd><code>Replace URL token auth with header authentication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/gitea_provider.py

<ul><li>Remove manual token extraction from API configuration<br> <li> Replace URL token parameters with <br><code>auth_settings=["AuthorizationHeaderToken"]</code><br> <li> Update five methods: <code>get_pull_request_diff</code>, <br><code>get_change_file_pull_request</code>, <code>get_languages</code>, <code>get_file_content</code>, <br><code>get_pr_commits</code><br> <li> Clean up URL construction logic by removing token parameter handling</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1991/files#diff-72248e291297fdc9b50150b3a369f958d8ac3c8e2b8fe69e7a6f9d72810aebdc">+9/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

