### PR TITLE
Limit Bitbucket webhook handling to an allow-list of repos + fix secret storage (split keys, safe IDs)

### DIFF
--- a/pr_agent/config_loader.py
+++ b/pr_agent/config_loader.py
@@ -98,7 +98,8 @@ def apply_secrets_manager_config():
             return
 
         if (hasattr(secret_provider, 'get_all_secrets') and
-            get_settings().get("CONFIG.SECRET_PROVIDER") == 'aws_secrets_manager'):
+            get_settings().get("CONFIG.SECRET_PROVIDER") == 'aws_secrets_manager' and 
+            get_settings().get("AWS_SECRETS_MANAGER.SECRET_ARN") != ""):
             try:
                 secrets = secret_provider.get_all_secrets()
                 if secrets:
@@ -109,7 +110,7 @@ def apply_secrets_manager_config():
     except Exception as e:
         try:
             from pr_agent.log import get_logger
-            get_logger().debug(f"Secret provider not configured: {e}")
+            get_logger().debug(f"Secret provider not configured: {e}, ensure SECRET_PROVIDER & SECRET_ARN values are set")
         except:
             # Fail completely silently if log module is not available
             pass

--- a/pr_agent/secret_providers/aws_secrets_manager_provider.py
+++ b/pr_agent/secret_providers/aws_secrets_manager_provider.py
@@ -48,8 +48,8 @@ class AWSSecretsManagerProvider(SecretProvider):
 
     def store_secret(self, secret_name: str, secret_value: str):
         try:
-            self.client.put_secret_value(
-                SecretId=secret_name,
+            self.client.create_secret(
+                Name=secret_name,
                 SecretString=secret_value
             )
         except Exception as e:

--- a/pr_agent/secret_providers/aws_secrets_manager_provider.py
+++ b/pr_agent/secret_providers/aws_secrets_manager_provider.py
@@ -53,6 +53,15 @@ class AWSSecretsManagerProvider(SecretProvider):
                 Name=secret_name,
                 SecretString=secret_value
             )
+        except self.client.exceptions.ResourceExistsException:
+            try:
+                self.client.put_secret_value(
+                    SecretId=secret_name,
+                    SecretString=secret_value
+                )
+            except Exception as e:
+                get_logger().error(f"Failed to update existing secret {secret_name} in AWS Secrets Manager: {e}")
+                raise e
         except Exception as e:
             get_logger().error(f"Failed to store secret {secret_name} in AWS Secrets Manager: {e}")
-            raise e 
+            raise e

--- a/pr_agent/secret_providers/aws_secrets_manager_provider.py
+++ b/pr_agent/secret_providers/aws_secrets_manager_provider.py
@@ -19,7 +19,8 @@ class AWSSecretsManagerProvider(SecretProvider):
 
             self.secret_arn = get_settings().get("aws_secrets_manager.secret_arn")
             if not self.secret_arn:
-                raise ValueError("AWS Secrets Manager ARN is not configured")
+                get_logger().warning("AWS Secrets Manager ARN is not configured — proceeding without it.")
+
         except Exception as e:
             get_logger().error(f"Failed to initialize AWS Secrets Manager Provider: {e}")
             raise e

--- a/pr_agent/servers/bitbucket_app.py
+++ b/pr_agent/servers/bitbucket_app.py
@@ -184,9 +184,12 @@ async def handle_github_webhooks(background_tasks: BackgroundTasks, request: Req
         data.get("data", {}).get("repository", {}).get("name")
     )
     allowed_repos = get_settings().get("BITBUCKET.ALLOWED_REPOSITORIES", [])
-
-    if repo_name_in_request not in allowed_repos:
-        get_logger().warning(f"Repository '{repo_name_in_request}' is not in the allowed list.")
+    
+    # Only enforce restriction if the list is non-empty
+    if allowed_repos and repo_name_in_request not in allowed_repos:
+        get_logger().warning(
+            f"Repository '{repo_name_in_request}' is not in the allowed list."
+        )
         return JSONResponse(
             status_code=403,
             content={"error": f"Repository '{repo_name_in_request}' is not allowed"}

--- a/pr_agent/servers/bitbucket_app.py
+++ b/pr_agent/servers/bitbucket_app.py
@@ -260,11 +260,8 @@ async def handle_installed_webhooks(request: Request, response: Response):
         data = await request.json()
         get_logger().info(data)
         shared_secret = data["sharedSecret"]
-        client_key = data["clientKey"]
         shared_secret_key_id = "bitbucket-app-" + data["principal"]["username"] + "-shared-secret" # store under this key in AWS secrets manager or GCP secrets provider
-        client_key_secret_id = "bitbucket-app-" + data["principal"]["username"] + "-client-key" # store under this key in AWS secrets manager or GCP secrets store
         secret_provider.store_secret(shared_secret_key_id, shared_secret)
-        secret_provider.store_secret(client_key_secret_id, client_key)
     except Exception as e:
         get_logger().error(f"Failed to register user: {e}")
         return JSONResponse({"error": "Unable to register user"}, status_code=500)

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -303,6 +303,7 @@ pr_commands = [
     "/improve --pr_code_suggestions.commitable_code_suggestions=true",
 ]
 avoid_full_files = false
+allowed_repositories = []
 
 [local]
 # LocalGitProvider settings - uncomment to use paths other than default


### PR DESCRIPTION
### **User description**
#### Why

    Bitbucket “workspace apps” fire webhooks for every repo. We only want ChatGPT PR review on a small subset to avoid unnecessary OpenAI usage.

    Found a bug: we retrieved clientKey and sharedSecret separately but stored them together in one JSON secret.

    AWS Secrets Manager name validation failed when the code tried to use raw clientKey (e.g. connection:5511210) as a secret id (colon not allowed). We need stable, safe secret IDs.

#### What’s changing

    Repo allow-list gate
     - Early exit with 403 if the incoming webhook’s repository.name is not in BITBUCKET_ALLOWED_REPOSITORIES.

    Secrets Key Name Rename
        Store secrets per Bitbucket workspace principal and also to distinguish among existing secrets in AWS:
        bitbucket-app-<data[username]>-shared-secret

        These Secret IDs are sanitized to conform to AWS rules.

   Make AWS_SECRET_ARN as not mandatory:
       I noticed that the pr-agent main config set in the AWS secrets manager was not used at all in the bitbucket_app
       

#### Error seen related to fetching shared secret:
```
"Failed to get secret connection:5511210 from AWS Secrets Manager: An error occurred (ValidationException) when calling the GetSecretValue operation: Invalid name. Must be a valid name containing alphanumeric characters, or any of the following: -/_+=.@!\n", "record": {"elapsed": {"repr": "0:09:49.042412", "seconds": 589.042412}
```
the secret stored in AWS looked like below
secret id: value of `data[username]` 
secret value (json object): `{"clientKey": "foo", "sharedSecret": "connection:5511210"}`

but while fetching this secret, PR-agent uses `getSecretValue("data[sharedSecret]")` instead of reverse looking up with the secret id `data[username]` and them parsing the sharedSecret from that secret json object. 
And removed storing unused `clientKey` secret since it is not being used.

#### Make AWS_SECRET_ARN as not mandatory:
Value of secret in AWS secrets
```
{
    "ARN": "arn:aws:secretsmanager:ap-southeast-3:XXXXXXXXX:secret:pr-agent-main-config-SOitzL",
    "Name": "pr-agent-main-config",
    "VersionId": "0c08efe2-551a-4172-a32b-b2d2f6602297",
    "SecretString": "{\"openai.key\":\"sk-proj-XXXXXXXXX\"}",
    "VersionStages": [
        "AWSCURRENT"
    ],
    "CreatedDate": "2025-08-13T09:44:30.644000+05:30"
}

pr-agent container config:
AWS_SECRETS_MANAGER__SECRET_ARN=arn:aws:secretsmanager:ap-southeast-3:XXXXXXXXX:secret:pr-agent-main-config-SOitzL
AWS_SECRETS_MANAGER__REGION_NAME=ap-southeast-3

bitbucket_app gets installed successfully, but when a webhook is triggered I expected that OpenAI API Key to be fetched from AWS Secrets Manager instead it didn't seem to pull from AWS secrets store (below error) - Not sure how pr-agent main configs are being initialised if config is stored in AWS secrets store.

(below error)
 {"text": "Error during LLM inference: litellm.AuthenticationError: AuthenticationError: OpenAIException - Incorrect API key provided: dummy_key. You can find your API key at https://platform.openai.com/account/api-keys.\n }
 
 however if OpenAI API Key is set it in container env variable, pr-agent review works without issues
```



New configuration added:
```
Env: BITBUCKET_ALLOWED_REPOSITORIES
Comma-separated list of repo names that are allowed to trigger PR review.
BITBUCKET_ALLOWED_REPOSITORIES=core-api,identity-service,docs-site
```
If `BITBUCKET__ALLOWED_REPOSITORIES` is unset, it will default to allowing any repositories for PR review to avoid breaking changes

Please note: this is just a draft and I need your suggestions/thoughts on this.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add repository allow-list for Bitbucket webhook filtering

- Fix secret storage by splitting keys and sanitizing IDs

- Make AWS_SECRET_ARN optional with graceful fallback

- Improve secret creation with ResourceExistsException handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  webhook["Bitbucket Webhook"] --> allowlist["Repository Allow-list Check"]
  allowlist --> |"allowed"| auth["JWT Authentication"]
  allowlist --> |"blocked"| reject["403 Response"]
  auth --> secrets["Fetch Shared Secret"]
  secrets --> process["Process PR Event"]
  install["App Installation"] --> store["Store Sanitized Secret"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitbucket_app.py</strong><dd><code>Add repository filtering and fix secret handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/servers/bitbucket_app.py

<ul><li>Add repository allow-list validation with 403 rejection for <br>unauthorized repos<br> <li> Change secret storage to use sanitized workspace-based keys<br> <li> Implement lifespan event handlers for startup logging<br> <li> Update secret retrieval to use new key format</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1994/files#diff-963a9de391ff22ad3083c3a28c1d5736d68a6e1e40b0bedb52d4bfd124325bad">+35/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws_secrets_manager_provider.py</strong><dd><code>Fix secret creation and make ARN optional</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/secret_providers/aws_secrets_manager_provider.py

<ul><li>Make AWS_SECRET_ARN optional with warning instead of error<br> <li> Change <code>put_secret_value</code> to <code>create_secret</code> for new secrets<br> <li> Add fallback to <code>put_secret_value</code> when secret already exists<br> <li> Improve error handling for ResourceExistsException</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1994/files#diff-2b758e5ef549e04478b0bfc0f6488e51226c94c117dab2698cdb5571d4df088b">+14/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config_loader.py</strong><dd><code>Add SECRET_ARN validation and improve logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/config_loader.py

<ul><li>Add null check for SECRET_ARN before calling get_all_secrets<br> <li> Improve debug message with configuration guidance</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1994/files#diff-35a8f47e651f179d8a5ad887b5d484e99650454fcc30efaa58945643bfc0b000">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Add repository allow-list configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml

- Add `allowed_repositories` configuration option for bitbucket_app


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1994/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

