### PR TITLE
fix: add temperature arg to self reflect of improve

### DIFF
--- a/pr_agent/tools/pr_code_suggestions.py
+++ b/pr_agent/tools/pr_code_suggestions.py
@@ -944,6 +944,7 @@ class PRCodeSuggestions:
             with get_logger().contextualize(command="self_reflect_on_suggestions"):
                 response_reflect, finish_reason_reflect = await self.ai_handler.chat_completion(model=model,
                                                                                                 system=system_prompt_reflect,
+                                                                                                temperature=get_settings().config.temperature,
                                                                                                 user=user_prompt_reflect)
         except Exception as e:
             get_logger().info(f"Could not reflect on suggestions, error: {e}")


### PR DESCRIPTION
### **User description**
https://github.com/qodo-ai/pr-agent/issues/1987#issuecomment-3177994746

Fix intermittent Azure temperature error in /improve command by adding explicit temperature parameter to the self-reflection chat_completion call.

The issue occurred because the self-reflection phase was using the method's default temperature value (0.2) instead of the configured value (1.0), causing failures when Azure models only support the default temperature. 

This change ensures consistent temperature usage across all AI calls in the PR code suggestions workflow.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Azure temperature error in /improve command

- Add explicit temperature parameter to self-reflection call

- Ensure consistent temperature usage across AI calls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR Code Suggestions"] --> B["Self Reflection Phase"]
  B --> C["AI Chat Completion"]
  C --> D["Temperature Parameter Added"]
  D --> E["Azure Compatibility Fixed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_code_suggestions.py</strong><dd><code>Add temperature parameter to self-reflection call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_code_suggestions.py

<ul><li>Add <code>temperature=get_settings().config.temperature</code> parameter to <br><code>chat_completion</code> call<br> <li> Fix inconsistent temperature usage in self-reflection phase<br> <li> Resolve Azure model compatibility issue</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/1996/files#diff-b57ba775e741d6f80bc4f8154b71330c011dae0ac43f3d0197e785b3e6b7117b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

