### PR TITLE
PR reviewer tool: add an opt-in work time estimation

### DIFF
--- a/docs/docs/tools/review.md
+++ b/docs/docs/tools/review.md
@@ -92,6 +92,10 @@ extra_instructions = "..."
         <td>If set to true, the tool will add a section that estimates the effort needed to review the PR. Default is true.</td>
       </tr>
       <tr>
+        <td><b>require_estimate_contribution_time_cost</b></td>
+        <td>If set to true, the tool will add a section that estimates the time required for a senior developer to create and submit such changes. Default is false.</td>
+      </tr>
+      <tr>
         <td><b>require_can_be_split_review</b></td>
         <td>If set to true, the tool will add a section that checks if the PR contains several themes, and can be split into smaller PRs. Default is false.</td>
       </tr>

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -148,6 +148,7 @@ def convert_to_markdown_v2(output_data: dict,
         "Insights from user's answers": "📝",
         "Code feedback": "🤖",
         "Estimated effort to review [1-5]": "⏱️",
+        "Contribution time cost estimate": "⏳",
         "Ticket compliance check": "🎫",
     }
     markdown_text = ""
@@ -207,6 +208,14 @@ def convert_to_markdown_v2(output_data: dict,
                     markdown_text += f"### {emoji} PR contains tests\n\n"
         elif 'ticket compliance check' in key_nice.lower():
             markdown_text = ticket_markdown_logic(emoji, markdown_text, value, gfm_supported)
+        elif 'contribution time cost estimate' in key_nice.lower():
+            if gfm_supported:
+                markdown_text += f"<tr><td>{emoji}&nbsp;<strong>Contribution time estimate</strong> (best, average, worst case): "
+                markdown_text += f"{value['best_case'].replace('m', ' minutes')} | {value['average_case'].replace('m', ' minutes')} | {value['worst_case'].replace('m', ' minutes')}"
+                markdown_text += f"</td></tr>\n"
+            else:
+                markdown_text += f"### {emoji} Contribution time estimate (best, average, worst case): "
+                markdown_text += f"{value['best_case'].replace('m', ' minutes')} | {value['average_case'].replace('m', ' minutes')} | {value['worst_case'].replace('m', ' minutes')}\n\n"
         elif 'security concerns' in key_nice.lower():
             if gfm_supported:
                 markdown_text += f"<tr><td>"

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -79,6 +79,7 @@ require_tests_review=true
 require_estimate_effort_to_review=true
 require_can_be_split_review=false
 require_security_review=true
+require_estimate_contribution_time_cost=false
 require_todo_scan=false
 require_ticket_analysis_review=true
 # general options

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -90,10 +90,11 @@ class TicketCompliance(BaseModel):
 {%- endif %}
 
 {%- if require_estimate_contribution_time_cost %}
+
 class ContributionTimeCostEstimate(BaseModel):
-    best_case: str = Field(description="Assume that an author is an expert in the involved technology stack and that there were no edge cases or unexpected bugs during development.", examples=["45m", "5h", "10h"])
-    average_case: str = Field(description="A typical required time to create and submit the changes if an author is more or less familiar with the technology and there were no significant unforeseen circumstances.", examples=["45m", "5h", "10h"])
-    worst_case: str = Field(description="Assume that contributing the changes could require a great deal of additional effort, such as investigating the topic, debugging the source code, or resolving unexpected errors.", examples=["45m", "5h", "10h"])
+    best_case: str = Field(description="An expert in the relevant technology stack, with no unforeseen issues or bugs during the work.", examples=["45m", "5h", "30h"])
+    average_case: str = Field(description="A senior developer with only brief familiarity with this specific technology stack, and no major unforeseen issues.", examples=["45m", "5h", "30h"])
+    worst_case: str = Field(description="A senior developer with no prior experience in this specific technology stack, requiring significant time for research, debugging, or resolving unexpected errors.", examples=["45m", "5h", "30h"])
 {%- endif %}
 
 class Review(BaseModel):
@@ -102,6 +103,9 @@ class Review(BaseModel):
 {%- endif %}
 {%- if require_estimate_effort_to_review %}
     estimated_effort_to_review_[1-5]: int = Field(description="Estimate, on a scale of 1-5 (inclusive), the time and effort required to review this PR by an experienced and knowledgeable developer. 1 means short and easy review , 5 means long and hard review. Take into account the size, complexity, quality, and the needed changes of the PR code diff.")
+{%- endif %}
+{%- if require_estimate_contribution_time_cost %}
+    contribution_time_cost_estimate: ContributionTimeCostEstimate = Field(description="An estimate of the time required to implement the changes, based on the quantity, quality, and complexity of the contribution, as well as the context from the PR description and commit messages.")
 {%- endif %}
 {%- if require_score %}
     score: str = Field(description="Rate this PR on a scale of 0-100 (inclusive), where 0 means the worst possible PR code, and 100 means PR code of the highest quality, without any bugs or performance issues, that is ready to be merged immediately and run in production at scale.")
@@ -121,9 +125,6 @@ class Review(BaseModel):
 {%- endif %}
 {%- if require_can_be_split_review %}
     can_be_split: List[SubPR] = Field(min_items=0, max_items=3, description="Can this PR, which contains {{ num_pr_files }} changed files in total, be divided into smaller sub-PRs with distinct tasks that can be reviewed and merged independently, regardless of the order ? Make sure that the sub-PRs are indeed independent, with no code dependencies between them, and that each sub-PR represent a meaningful independent task. Output an empty list if the PR code does not need to be split.")
-{%- endif %}
-{%- if require_estimate_contribution_time_cost %}
-    contribution_time_cost_estimate: ContributionTimeEstimate = Field(description="Based on the contribution quantity, quality, and complexity, estimate the time that may be required for a senior developer to create and submit such changes.")
 {%- endif %}
 
 class PRReview(BaseModel):
@@ -179,6 +180,15 @@ review:
     - ...
     title: ...
   - ...
+{%- endif %}
+{%- if require_estimate_contribution_time_cost %}
+  contribution_time_cost_estimate:
+    best_case: |
+      ...
+    average_case: |
+      ...
+    worst_case: |
+      ...
 {%- endif %}
 ```
 
@@ -308,6 +318,15 @@ review:
     - ...
     title: ...
   - ...
+{%- endif %}
+{%- if require_estimate_contribution_time_cost %}
+  contribution_time_cost_estimate:
+    best_case: |
+      ...
+    average_case: |
+      ...
+    worst_case: |
+      ...
 {%- endif %}
 ```
 (replace '...' with the actual values)

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -89,6 +89,13 @@ class TicketCompliance(BaseModel):
     requires_further_human_verification: str = Field(description="Bullet-point list of items from the 'ticket_requirements' section above that cannot be assessed through code review alone, are unclear, or need further human review (e.g., browser testing, UI checks). Leave empty if all 'ticket_requirements' were marked as fully compliant or not compliant")
 {%- endif %}
 
+{%- if require_estimate_contribution_time_cost %}
+class ContributionTimeCostEstimate(BaseModel):
+    best_case: str = Field(description="Assume that an author is an expert in the involved technology stack and that there were no edge cases or unexpected bugs during development.", examples=["45m", "5h", "10h"])
+    average_case: str = Field(description="A typical required time to create and submit the changes if an author is more or less familiar with the technology and there were no significant unforeseen circumstances.", examples=["45m", "5h", "10h"])
+    worst_case: str = Field(description="Assume that contributing the changes could require a great deal of additional effort, such as investigating the topic, debugging the source code, or resolving unexpected errors.", examples=["45m", "5h", "10h"])
+{%- endif %}
+
 class Review(BaseModel):
 {%- if related_tickets %}
     ticket_compliance_check: List[TicketCompliance] = Field(description="A list of compliance checks for the related tickets")
@@ -114,6 +121,9 @@ class Review(BaseModel):
 {%- endif %}
 {%- if require_can_be_split_review %}
     can_be_split: List[SubPR] = Field(min_items=0, max_items=3, description="Can this PR, which contains {{ num_pr_files }} changed files in total, be divided into smaller sub-PRs with distinct tasks that can be reviewed and merged independently, regardless of the order ? Make sure that the sub-PRs are indeed independent, with no code dependencies between them, and that each sub-PR represent a meaningful independent task. Output an empty list if the PR code does not need to be split.")
+{%- endif %}
+{%- if require_estimate_contribution_time_cost %}
+    contribution_time_cost_estimate: ContributionTimeEstimate = Field(description="Based on the contribution quantity, quality, and complexity, estimate the time that may be required for a senior developer to create and submit such changes.")
 {%- endif %}
 
 class PRReview(BaseModel):

--- a/pr_agent/tools/pr_reviewer.py
+++ b/pr_agent/tools/pr_reviewer.py
@@ -85,6 +85,7 @@ class PRReviewer:
             "require_score": get_settings().pr_reviewer.require_score_review,
             "require_tests": get_settings().pr_reviewer.require_tests_review,
             "require_estimate_effort_to_review": get_settings().pr_reviewer.require_estimate_effort_to_review,
+            "require_estimate_contribution_time_cost": get_settings().pr_reviewer.require_estimate_contribution_time_cost,
             'require_can_be_split_review': get_settings().pr_reviewer.require_can_be_split_review,
             'require_security_review': get_settings().pr_reviewer.require_security_review,
             'require_todo_scan': get_settings().pr_reviewer.get("require_todo_scan", False),

--- a/tests/unittest/test_convert_to_markdown.py
+++ b/tests/unittest/test_convert_to_markdown.py
@@ -236,12 +236,25 @@ class TestConvertToMarkdown:
         expected_output = textwrap.dedent(f"""
             {PRReviewHeader.REGULAR.value} 🔍
 
+            Here are some key observations to aid the review process:
+
             <table>
             <tr><td>⏳&nbsp;<strong>Contribution time estimate</strong> (best, average, worst case): 1h | 2h | 30 minutes</td></tr>
             </table>
         """)
-
         assert convert_to_markdown_v2(input_data).strip() == expected_output.strip()
+
+        # Non-GFM branch
+        expected_output_no_gfm = textwrap.dedent(f"""
+        {PRReviewHeader.REGULAR.value} 🔍
+
+        Here are some key observations to aid the review process:
+
+        ### ⏳ Contribution time estimate (best, average, worst case): 1h | 2h | 30 minutes
+
+        """)
+        assert convert_to_markdown_v2(input_data, gfm_supported=False).strip() == expected_output_no_gfm.strip()
+
 
     # Tests that the function works correctly with an empty dictionary input
     def test_empty_dictionary_input(self):

--- a/tests/unittest/test_convert_to_markdown.py
+++ b/tests/unittest/test_convert_to_markdown.py
@@ -222,6 +222,27 @@ class TestConvertToMarkdown:
 
         assert convert_to_markdown_v2(input_data).strip() == expected_output.strip()
 
+    def test_contribution_time_cost_estimate(self):
+        input_data = {
+            'review': {
+                'contribution_time_cost_estimate': {
+                    'best_case': '1h',
+                    'average_case': '2h',
+                    'worst_case': '30m',
+                }
+            }
+        }
+
+        expected_output = textwrap.dedent(f"""
+            {PRReviewHeader.REGULAR.value} 🔍
+
+            <table>
+            <tr><td>⏳&nbsp;<strong>Contribution time estimate</strong> (best, average, worst case): 1h | 2h | 30 minutes</td></tr>
+            </table>
+        """)
+
+        assert convert_to_markdown_v2(input_data).strip() == expected_output.strip()
+
     # Tests that the function works correctly with an empty dictionary input
     def test_empty_dictionary_input(self):
         input_data = {}


### PR DESCRIPTION
### **User description**
<img width="1471" height="706" alt="pr-agent" src="https://github.com/user-attachments/assets/d440a9d4-c344-4d17-b662-da27fae810cf" />

### Description

In terms of evaluating a developer's time, this is similar to `estimated effort to review` but it is more powerful because it replaces a vague 1-5 score with a best/average/worst estimation in hours. The new opt-in field shifts the question from "_how long could it take to review this amount of changes?_" to "_how long could it take to contribute this amount of changes?_"

### Why

A busy team lead and a business owner, who simply cannot get deep into the low-level details of each submitted work, want to get a quick rough (MIN / MAX range) estimate (in hours) of the effort it could take to develop and submit a Pull Request.

## Advantages

- The "best," "average," and "worst" time estimation gives more granularity for team leads and project managers.
- The best/average/worst time duration can be used for comparison with the tracked time. It is expected that sometimes a developer will exceed the "worst" time because an AI cannot know all the details, but if a remote developer continuously over-tracks the "worst" estimate, this is a signal that something may be wrong and is worth special attention from a team lead.
- The new field is opt-in, so users may decide whether they need it.

### Breaking changes

No.

### How I tested the changes

I have been testing my fork of PR-agent in my team, and I am happy with the new optional field.


___

### **PR Type**
Enhancement


___

### **Description**
- Add optional contribution time cost estimation feature

- Provide best/average/worst case time estimates in hours

- Include configuration option and documentation updates

- Add comprehensive test coverage for new functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Configuration"] --> B["PR Reviewer Tool"]
  B --> C["Time Estimation Logic"]
  C --> D["Markdown Output"]
  E["Prompts Template"] --> C
  F["Tests"] --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Add markdown formatting for time estimates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/utils.py

<ul><li>Add emoji mapping for contribution time cost estimate<br> <li> Implement markdown formatting logic for time estimates<br> <li> Handle both GFM and regular markdown formats<br> <li> Convert time units from 'm' to 'minutes' for display</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2006/files#diff-6b9df72d53c6f0d89fb142c210238a276c0782305e0024d16fbfcaf72c2e2b53">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer.py</strong><dd><code>Enable contribution time estimation in reviewer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/tools/pr_reviewer.py

<ul><li>Add <code>require_estimate_contribution_time_cost</code> parameter<br> <li> Pass configuration setting to PR reviewer initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2006/files#diff-8e265068e189a06852605cc694b03e92b523b4f8162077a2f3455ced4cdad8dc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer_prompts.toml</strong><dd><code>Add prompts and models for time estimation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/pr_reviewer_prompts.toml

<ul><li>Define <code>ContributionTimeCostEstimate</code> data model<br> <li> Add best/average/worst case time fields with examples<br> <li> Integrate time estimation into Review model<br> <li> Update prompt templates with conditional rendering</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2006/files#diff-2e1ca45d2d8635b5f9cde801d9d210f6516e7f15d45dd9b0be134ac91e7a2e63">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_convert_to_markdown.py</strong><dd><code>Add tests for time estimation feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_convert_to_markdown.py

<ul><li>Add comprehensive test for contribution time cost estimate<br> <li> Test markdown table formatting with time values<br> <li> Verify proper display of best/average/worst cases</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2006/files#diff-48e28c70a7fa0ad268cc0cd35739816da980187199079f2c78eeffff330ce450">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>review.md</strong><dd><code>Document time estimation configuration option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/tools/review.md

<ul><li>Document new <code>require_estimate_contribution_time_cost</code> option<br> <li> Explain feature purpose for senior developer time estimation<br> <li> Set default value to false (opt-in feature)</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2006/files#diff-8e6363749b8b0a82468e5fbb0796cee806dc48e70e7472b04088d56d2c415094">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Add configuration setting for time estimation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/configuration.toml

<ul><li>Add <code>require_estimate_contribution_time_cost=false</code> setting<br> <li> Make feature opt-in by default</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2006/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

