### PR TITLE
Set a status for comments on azure devops

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -79,7 +79,8 @@ class AzureDevopsProvider(GitProvider):
                 right_file_start=CommentPosition(offset=1, line=relevant_lines_start),
                 right_file_end=CommentPosition(offset=1, line=relevant_lines_end))
             comment = Comment(content=body, comment_type=1)
-            thread = CommentThread(comments=[comment], thread_context=thread_context)
+            status = get_settings().azure_devops.get("default_comment_status", "closed")
+            thread = CommentThread(comments=[comment], thread_context=thread_context, status=status)
             try:
                 self.azure_devops_client.create_thread(
                     comment_thread=thread,

--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -57,6 +57,7 @@ class AzureDevopsProvider(GitProvider):
         Publishes code suggestions as comments on the PR.
         """
         post_parameters_list = []
+        status = get_settings().azure_devops.get("default_comment_status", "closed")
         for suggestion in code_suggestions:
             body = suggestion['body']
             relevant_file = suggestion['relevant_file']
@@ -79,7 +80,6 @@ class AzureDevopsProvider(GitProvider):
                 right_file_start=CommentPosition(offset=1, line=relevant_lines_start),
                 right_file_end=CommentPosition(offset=1, line=relevant_lines_end))
             comment = Comment(content=body, comment_type=1)
-            status = get_settings().azure_devops.get("default_comment_status", "closed")
             thread = CommentThread(comments=[comment], thread_context=thread_context, status=status)
             try:
                 self.azure_devops_client.create_thread(


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add configurable status setting for Azure DevOps comments

- Enable default comment status control via settings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Settings"] --> B["Get default_comment_status"]
  B --> C["CommentThread with status"]
  C --> D["Azure DevOps API"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_provider.py</strong><dd><code>Add configurable comment status support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/azuredevops_provider.py

<ul><li>Add status parameter retrieval from settings<br> <li> Pass status to CommentThread constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2011/files#diff-1a90ea92bcfba3cf9f1dbc298d2e570566f4c439cb3650ee746cebdb02ca4a0b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

