### PR TITLE
fix: correct variable name for last merge source commit in Azure DevOps provider

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -196,7 +196,7 @@ class AzureDevopsProvider(GitProvider):
                 return self.diff_files
 
             base_sha = self.pr.last_merge_target_commit
-            head_sha = self.pr.last_merge_source_commit
+            head_sha = self.pr.last_merge_commit
 
             # Get PR iterations
             iterations = self.azure_devops_client.get_pull_request_iterations(


### PR DESCRIPTION
### **User description**
fixes: #2012


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect variable name in Azure DevOps provider

- Changed `last_merge_source_commit` to `last_merge_commit`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Azure DevOps Provider"] --> B["get_diff_files method"]
  B --> C["Variable name correction"]
  C --> D["last_merge_commit"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azuredevops_provider.py</strong><dd><code>Variable name correction for merge commit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/git_providers/azuredevops_provider.py

<ul><li>Fixed variable name from <code>last_merge_source_commit</code> to <code>last_merge_commit</code><br> <li> Corrected reference in <code>get_diff_files</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/pr-agent/pull/2018/files#diff-1a90ea92bcfba3cf9f1dbc298d2e570566f4c439cb3650ee746cebdb02ca4a0b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

