### PR TITLE
chore: add error log on model prediction failure

### DIFF
--- a/pr_agent/algo/pr_processing.py
+++ b/pr_agent/algo/pr_processing.py
@@ -329,9 +329,9 @@ async def retry_with_fallback_models(f: Callable, model_type: ModelType = ModelT
             )
             get_settings().set("openai.deployment_id", deployment_id)
             return await f(model)
-        except:
+        except Exception as e:
             get_logger().warning(
-                f"Failed to generate prediction with {model}"
+                f"Failed to generate prediction with {model}: {e}",
             )
             if i == len(all_models) - 1:  # If it's the last iteration
                 raise Exception(f"Failed to generate prediction with any model of {all_models}")


### PR DESCRIPTION
Add error message to logging for model prediction failures in retry_with_fallback_models, capturing the exception message. 

I’m currently encountering PR-Agent issue #2042 and need richer logs to investigate. No functional changes; logging-only.